### PR TITLE
feat: add authorization middleware

### DIFF
--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -49,7 +49,10 @@ paths:
     get:
       summary: Get an employee by ID.
       operationId: getEmployeeByID
-      description: Returns the employee with the specified identifier.
+      description: |
+        Returns the employee with the specified identifier.
+
+        Required roles: `waste_operator`, `manager`
       tags:
         - Employee
       security:

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -51,12 +51,10 @@ paths:
       operationId: getEmployeeByID
       description: |
         Returns the employee with the specified identifier.
-
-        Required roles: `waste_operator`, `manager`
       tags:
         - Employee
       security:
-        - BearerAuth: []
+        - BearerAuth: [waste_operator, manager]
       parameters:
         - $ref: "#/components/parameters/EmployeeIdParam"
       responses:

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -116,6 +116,7 @@ components:
           enum:
             - bad_request
             - unauthorized
+            - forbidden
             - not_found
             - internal_server_error
         message:

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -49,8 +49,7 @@ paths:
     get:
       summary: Get an employee by ID.
       operationId: getEmployeeByID
-      description: |
-        Returns the employee with the specified identifier.
+      description: Returns the employee with the specified identifier.
       tags:
         - Employee
       security:

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/goncalo-marques/ecomap/server/internal/authn"
+	"github.com/goncalo-marques/ecomap/server/internal/authz"
 	"github.com/goncalo-marques/ecomap/server/internal/config"
 	"github.com/goncalo-marques/ecomap/server/internal/logging"
 	"github.com/goncalo-marques/ecomap/server/internal/service"
@@ -80,6 +81,9 @@ func main() {
 
 	authnService := authn.New([]byte(jwtSigningKey))
 
+	// Set up authorization service.
+	authzService := authz.New(transporthttp.AuthzRoles, authnService)
+
 	// Set up service.
 	service := service.New(authnService, store)
 
@@ -93,7 +97,7 @@ func main() {
 		addressHTTP = serviceConfig.ServerHTTP.Address
 	}
 
-	handlerHTTP := transporthttp.New(service)
+	handlerHTTP := transporthttp.New(authzService, service)
 
 	serverHTTP := &http.Server{
 		Addr:     addressHTTP,

--- a/server/database/migrations/000001_initial_database.down.sql
+++ b/server/database/migrations/000001_initial_database.down.sql
@@ -1,43 +1,43 @@
 -- Route employees.
-DROP TABLE public.routes_employees;
-DROP TYPE public.routes_employees_employee_role;
+DROP TABLE routes_employees;
+DROP TYPE routes_employees_employee_role;
 
 -- Route containers.
-DROP TABLE public.routes_containers;
+DROP TABLE routes_containers;
 
 -- Routes.
-DROP TABLE public.routes;
+DROP TABLE routes;
 
 -- Warehouse trucks.
-DROP TABLE public.warehouses_trucks;
+DROP TABLE warehouses_trucks;
 
 -- Warehouses.
-DROP TABLE public.warehouses;
+DROP TABLE warehouses;
 
 -- Trucks.
-DROP TABLE public.trucks;
+DROP TABLE trucks;
 
 -- User container bookmarks.
-DROP TABLE public.users_container_bookmarks;
+DROP TABLE users_container_bookmarks;
 
 -- Container reports.
-DROP TABLE public.containers_reports;
-DROP TYPE public.containers_reports_issue_type;
+DROP TABLE containers_reports;
+DROP TYPE containers_reports_issue_type;
 
 -- Containers.
-DROP TABLE public.containers;
-DROP TYPE public.containers_category;
+DROP TABLE containers;
+DROP TYPE containers_category;
 
 -- Employees.
-DROP TABLE public.employees;
-DROP TYPE public.employees_role;
+DROP TABLE employees;
+DROP TYPE employees_role;
 
 -- Users.
-DROP TABLE public.users;
+DROP TABLE users;
 
 -- Functions.
-DROP FUNCTION public.enforce_lower_case_username();
-DROP FUNCTION public.update_modified_time();
+DROP FUNCTION enforce_lower_case_username();
+DROP FUNCTION update_modified_time();
 
 -- Extensions.
 DROP EXTENSION pgrouting CASCADE;

--- a/server/database/migrations/000001_initial_database.up.sql
+++ b/server/database/migrations/000001_initial_database.up.sql
@@ -77,11 +77,11 @@ CREATE TRIGGER employees_update_modified_time
 CREATE TYPE containers_category AS ENUM ('general', 'paper', 'plastic', 'metal', 'glass', 'organic', 'hazardous');
 
 CREATE TABLE containers (
-    id              uuid                        NOT NULL    DEFAULT GEN_RANDOM_UUID(),
-    category        containers_category  NOT NULL,
-    geom            geometry                    NOT NULL,
-    created_time    timestamp                   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
-    modified_time   timestamp                   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    id              uuid                NOT NULL    DEFAULT GEN_RANDOM_UUID(),
+    category        containers_category NOT NULL,
+    geom            geometry            NOT NULL,
+    created_time    timestamp           NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    modified_time   timestamp           NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT containers_pkey  PRIMARY KEY (id)
 );
 
@@ -94,16 +94,16 @@ CREATE TRIGGER containers_update_modified_time
 CREATE TYPE containers_reports_issue_type AS ENUM ('full', 'vandalized', 'misplaced', 'non-existent', 'other');
 
 CREATE TABLE containers_reports (
-    id              uuid                                    NOT NULL    DEFAULT GEN_RANDOM_UUID(),
-    container_id    uuid                                    NOT NULL,
-    issue_type      containers_reports_issue_type    NOT NULL,
+    id              uuid                            NOT NULL    DEFAULT GEN_RANDOM_UUID(),
+    container_id    uuid                            NOT NULL,
+    issue_type      containers_reports_issue_type   NOT NULL,
     description     varchar(500),
     attachment      bytea,
-    issuer_id       uuid                                    NOT NULL,
+    issuer_id       uuid                            NOT NULL,
     resolver_id     uuid,
-    resolved        boolean                                 NOT NULL    DEFAULT FALSE,
-    created_time    timestamp                               NOT NULL    DEFAULT CURRENT_TIMESTAMP,
-    modified_time   timestamp                               NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    resolved        boolean                         NOT NULL    DEFAULT FALSE,
+    created_time    timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    modified_time   timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT containers_reports_pkey              PRIMARY KEY (id),
     CONSTRAINT containers_reports_container_id_fkey FOREIGN KEY (container_id)  REFERENCES containers (id),
     CONSTRAINT containers_reports_issuer_id_fkey    FOREIGN KEY (issuer_id)     REFERENCES users (id),
@@ -211,10 +211,10 @@ CREATE INDEX routes_containers_created_time_idx ON routes_containers (created_ti
 CREATE TYPE routes_employees_employee_role AS ENUM ('driver', 'collector');
 
 CREATE TABLE routes_employees (
-    route_id        uuid                                    NOT NULL,
-    employee_id     uuid                                    NOT NULL,
-    employee_role   routes_employees_employee_role   NOT NULL,
-    created_time    timestamp                               NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    route_id        uuid                            NOT NULL,
+    employee_id     uuid                            NOT NULL,
+    employee_role   routes_employees_employee_role  NOT NULL,
+    created_time    timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT routes_employees_pkey                PRIMARY KEY (route_id, employee_id),
     CONSTRAINT routes_employees_route_id_fkey       FOREIGN KEY (route_id)              REFERENCES routes (id),
     CONSTRAINT routes_employees_employee_id_fkey    FOREIGN KEY (employee_id)           REFERENCES employees (id)

--- a/server/database/migrations/000001_initial_database.up.sql
+++ b/server/database/migrations/000001_initial_database.up.sql
@@ -46,19 +46,19 @@ CREATE TRIGGER users_update_modified_time
 CREATE TYPE employees_role AS ENUM ('waste_operator', 'manager');
 
 CREATE TABLE employees (
-    id              uuid                    NOT NULL    DEFAULT GEN_RANDOM_UUID(),
-    username        varchar(50)             NOT NULL,
-    password        varchar(60)             NOT NULL,
-    first_name      varchar(50)             NOT NULL,
-    last_name       varchar(50)             NOT NULL,
-    role            employees_role   NOT NULL,
-    date_of_birth   date                    NOT NULL,
-    phone_number    varchar(20)             NOT NULL,
-    geom            geometry                NOT NULL,
-    schedule_start  time                    NOT NULL,
-    schedule_end    time                    NOT NULL,
-    created_time    timestamp               NOT NULL    DEFAULT CURRENT_TIMESTAMP,
-    modified_time   timestamp               NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    id              uuid            NOT NULL    DEFAULT GEN_RANDOM_UUID(),
+    username        varchar(50)     NOT NULL,
+    password        varchar(60)     NOT NULL,
+    first_name      varchar(50)     NOT NULL,
+    last_name       varchar(50)     NOT NULL,
+    role            employees_role  NOT NULL,
+    date_of_birth   date            NOT NULL,
+    phone_number    varchar(20)     NOT NULL,
+    geom            geometry        NOT NULL,
+    schedule_start  time            NOT NULL,
+    schedule_end    time            NOT NULL,
+    created_time    timestamp       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
+    modified_time   timestamp       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT employees_pkey           PRIMARY KEY (id),
     CONSTRAINT employees_username_key   UNIQUE (username)
 );

--- a/server/internal/authn/jwt.go
+++ b/server/internal/authn/jwt.go
@@ -14,16 +14,34 @@ const (
 
 var ErrJWTInvalid = errors.New("invalid jwt") // Returned when the JWT is invalid.
 
+// SubjectRole defines the role of subject.
+type SubjectRole string
+
+const (
+	SubjectRoleUser          SubjectRole = "user"
+	SubjectRoleWasteOperator SubjectRole = "waste_operator"
+	SubjectRoleManager       SubjectRole = "manager"
+)
+
+// Claims defines the JSON Web Token claims structure.
+type Claims struct {
+	jwt.RegisteredClaims
+	Roles []SubjectRole `json:"roles,omitempty"`
+}
+
 // NewJWT returns a new signed JSON Web Token with an expiration time of 24 hours and the specified claims.
-func (s *service) NewJWT(subject string) (string, error) {
+func (s *service) NewJWT(subject string, subjectRoles []SubjectRole) (string, error) {
 	expiresAt := time.Now().Add(jwtExpirationTime).UTC()
 	issuedAt := time.Now().UTC()
 
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
-		Issuer:    jwtIssuer,
-		Subject:   subject,
-		ExpiresAt: jwt.NewNumericDate(expiresAt),
-		IssuedAt:  jwt.NewNumericDate(issuedAt),
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    jwtIssuer,
+			Subject:   subject,
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(issuedAt),
+		},
+		Roles: subjectRoles,
 	})
 
 	tokenString, err := token.SignedString(s.jwtSigningKey)
@@ -36,18 +54,18 @@ func (s *service) NewJWT(subject string) (string, error) {
 
 // ParseJWT parses the given token and returns the associated subject.
 // If the token is invalid, ErrJWTInvalid is returned.
-func (s *service) ParseJWT(tokenString string) (string, error) {
-	var claims jwt.RegisteredClaims
+func (s *service) ParseJWT(tokenString string) (Claims, error) {
+	var claims Claims
 	token, err := jwt.ParseWithClaims(tokenString, &claims, func(t *jwt.Token) (interface{}, error) {
 		return s.jwtSigningKey, nil
 	})
 	if err != nil {
-		return "", err
+		return Claims{}, err
 	}
 
 	if !token.Valid {
-		return "", ErrJWTInvalid
+		return Claims{}, ErrJWTInvalid
 	}
 
-	return claims.Subject, nil
+	return claims, nil
 }

--- a/server/internal/authn/jwt.go
+++ b/server/internal/authn/jwt.go
@@ -30,7 +30,7 @@ type Claims struct {
 }
 
 // NewJWT returns a new signed JSON Web Token with an expiration time of 24 hours and the specified claims.
-func (s *service) NewJWT(subject string, subjectRoles ...SubjectRole) (string, error) {
+func (s *service) NewJWT(subject string, subjectRoles []SubjectRole) (string, error) {
 	expiresAt := time.Now().Add(jwtExpirationTime).UTC()
 	issuedAt := time.Now().UTC()
 

--- a/server/internal/authn/jwt.go
+++ b/server/internal/authn/jwt.go
@@ -30,7 +30,7 @@ type Claims struct {
 }
 
 // NewJWT returns a new signed JSON Web Token with an expiration time of 24 hours and the specified claims.
-func (s *service) NewJWT(subject string, subjectRoles []SubjectRole) (string, error) {
+func (s *service) NewJWT(subject string, subjectRoles ...SubjectRole) (string, error) {
 	expiresAt := time.Now().Add(jwtExpirationTime).UTC()
 	issuedAt := time.Now().UTC()
 

--- a/server/internal/authn/jwt.go
+++ b/server/internal/authn/jwt.go
@@ -14,7 +14,7 @@ const (
 
 var ErrJWTInvalid = errors.New("invalid jwt") // Returned when the JWT is invalid.
 
-// SubjectRole defines the role of subject.
+// SubjectRole defines the role of the subject.
 type SubjectRole string
 
 const (

--- a/server/internal/authz/authz.go
+++ b/server/internal/authz/authz.go
@@ -4,21 +4,8 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/authn"
 )
 
-// RoleMap defines the map of roles required to access a method in a given endpoint.
-//
-// Example:
-//
-//	var roleMap RoleMap = RoleMap{
-//		"/employees/{employeeId}": {
-//			http.MethodGet:    []string{"user", "admin"},
-//			http.MethodDelete: []string{"admin"},
-//		},
-//	}
-type RoleMap map[string]map[string][]string
-
 // Roles defines the authorization roles structure.
 type Roles struct {
-	RoleMap        RoleMap  // Map of required roles.
 	AuthzWildcards []string // Wildcards that require authorization.
 	AdminRole      string   // Role that can access all identifiers (bypasses AuthzWildcards).
 }

--- a/server/internal/authz/authz.go
+++ b/server/internal/authz/authz.go
@@ -1,0 +1,43 @@
+package authz
+
+import (
+	"github.com/goncalo-marques/ecomap/server/internal/authn"
+)
+
+// RoleMap defines the map of roles required to access a method in a given endpoint.
+//
+// Example:
+//
+//	var roleMap RoleMap = RoleMap{
+//		"/employees/{employeeId}": {
+//			http.MethodGet:    []string{"user", "admin"},
+//			http.MethodDelete: []string{"admin"},
+//		},
+//	}
+type RoleMap map[string]map[string][]string
+
+// Roles defines the authorization roles structure.
+type Roles struct {
+	RoleMap        RoleMap  // Map of required roles.
+	AuthzWildcards []string // Wildcards that require authorization.
+	AdminRole      string   // Role that can access all identifiers (bypasses AuthzWildcards).
+}
+
+// AuthenticationService defines the authentication service interface.
+type AuthenticationService interface {
+	ParseJWT(tokenString string) (authn.Claims, error)
+}
+
+// service defines the authorization service structure.
+type service struct {
+	roles        Roles
+	authnService AuthenticationService
+}
+
+// New returns a new authorization service.
+func New(roles Roles, authnService AuthenticationService) *service {
+	return &service{
+		roles:        roles,
+		authnService: authnService,
+	}
+}

--- a/server/internal/authz/middleware.go
+++ b/server/internal/authz/middleware.go
@@ -1,6 +1,30 @@
 package authz
 
-import "net/http"
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	spec "github.com/goncalo-marques/ecomap/server/api/ecomap"
+	"github.com/goncalo-marques/ecomap/server/internal/authn"
+)
+
+const (
+	requestHeaderKeyAuthorization = "Authorization"
+	bearerSchemaPrefix            = "Bearer "
+
+	descriptionFailedToFindBearerSchemaPrefix = "authz: failed to find bearer schema prefix"
+	descriptionFailedToParseJWT               = "authz: failed to parse jwt"
+	descriptionFailedToValidateRoles          = "authz: failed to validate roles"
+)
+
+var (
+	ErrAuthorizationHeaderInvalid = errors.New("invalid authorization header") // Returned when the Authorization header is invalid.
+	ErrRolesInvalid               = errors.New("invalid roles")                // Returned when the subject does not contain any of the required roles.
+	ErrAuthorizationInvalid       = errors.New("invalid authorization")        // Returned when the subject is not the one actually contained in the path wildcard.
+)
 
 // ErrorHandlerFunc defines the function to handle an error in the middleware.
 type ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
@@ -15,6 +39,7 @@ type MiddlewareOptions struct {
 // Middleware validates the JWT in the Authorization header and ensures that the associated subject has the necessary
 // roles to access an endpoint based on the configured Roles.
 func (s *service) Middleware(options MiddlewareOptions) func(http.Handler) http.Handler {
+	// unauthorized defines a function to handle an unauthorized HTTP response.
 	unauthorized := options.UnauthorizedHandlerFunc
 	if unauthorized == nil {
 		unauthorized = func(w http.ResponseWriter, r *http.Request, err error) {
@@ -22,6 +47,7 @@ func (s *service) Middleware(options MiddlewareOptions) func(http.Handler) http.
 		}
 	}
 
+	// forbidden defines a function to handle a forbidden HTTP response.
 	forbidden := options.ForbiddenHandlerFunc
 	if forbidden == nil {
 		forbidden = func(w http.ResponseWriter, r *http.Request, err error) {
@@ -29,6 +55,7 @@ func (s *service) Middleware(options MiddlewareOptions) func(http.Handler) http.
 		}
 	}
 
+	// internalServerError defines a function to handle an internal server error HTTP response.
 	internalServerError := options.InternalServerErrorHandlerFunc
 	if internalServerError == nil {
 		internalServerError = func(w http.ResponseWriter, r *http.Request, err error) {
@@ -36,16 +63,109 @@ func (s *service) Middleware(options MiddlewareOptions) func(http.Handler) http.
 		}
 	}
 
+	// validateRoles defines a function to validate the subject roles to access the endpoint.
+	validateRoles := func(r *http.Request, requiredRoles []string, subjectRoles []string, subject string) error {
+		// Check that the subject contains at least one of the required roles.
+		containedRoles := make([]string, 0, len(requiredRoles))
+		for _, requiredRole := range requiredRoles {
+			if !slices.Contains(subjectRoles, requiredRole) {
+				continue
+			}
+
+			containedRoles = append(containedRoles, requiredRole)
+		}
+
+		if len(containedRoles) == 0 {
+			return ErrRolesInvalid
+		}
+
+		// Check that the subject contains the Admin role.
+		if slices.Contains(subjectRoles, s.roles.AdminRole) {
+			return nil
+		}
+
+		// Check that the subject is the one actually contained in the path wildcard.
+		var requiredAuthorization string
+		for _, wildcard := range s.roles.AuthzWildcards {
+			pathValue := r.PathValue(wildcard)
+			if len(pathValue) == 0 {
+				continue
+			}
+
+			requiredAuthorization = pathValue
+		}
+
+		if len(requiredAuthorization) == 0 {
+			// There is no authorization wildcard.
+			return nil
+		}
+		if requiredAuthorization != subject {
+			return ErrAuthorizationInvalid
+		}
+
+		// This means that the subject has the necessary roles to access the endpoint and has the authority of the data
+		// they are trying to manipulate.
+		return nil
+	}
+
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
+	// TODO: test each branch
 	return func(nextHandler http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// TODO: use option errors
-			// TODO: Authorization: Bearer <token>
-			// TODO: validate jwt
-			// TODO: fail if role map do not contain pattern
-			// TODO: don't validate roles for empty
-			// TODO: guarantee contain necessary roles
-			// TODO: admin early return in validation
-			// TODO: guarantee non-admin contains the same id as the one defined
+			ctx := r.Context()
+
+			// Get required roles.
+			var requiredRoles []string
+			bearerAuthScopes := ctx.Value(spec.BearerAuthScopes)
+			if bearerAuthScopes != nil {
+				requiredRoles = bearerAuthScopes.([]string)
+			}
+
+			// Check if there are any required roles.
+			if len(requiredRoles) != 0 {
+				// Get token from the Authorization header.
+				authorizationValue := r.Header.Get(requestHeaderKeyAuthorization)
+				token, ok := strings.CutPrefix(authorizationValue, bearerSchemaPrefix)
+				if !ok {
+					unauthorized(w, r, fmt.Errorf("%s: %w", descriptionFailedToFindBearerSchemaPrefix, ErrAuthorizationHeaderInvalid))
+					return
+				}
+
+				// Get JWT claims.
+				claims, err := s.authnService.ParseJWT(token)
+				if err != nil {
+					switch {
+					case errors.Is(err, authn.ErrJWTInvalid):
+						unauthorized(w, r, fmt.Errorf("%s: %w", descriptionFailedToParseJWT, ErrAuthorizationHeaderInvalid))
+					default:
+						internalServerError(w, r, fmt.Errorf("%s: %w", descriptionFailedToParseJWT, err))
+					}
+
+					return
+				}
+
+				// Evaluate roles.
+				subjectRoles := make([]string, len(claims.Roles))
+				for i, role := range claims.Roles {
+					subjectRoles[i] = string(role)
+				}
+
+				err = validateRoles(r, requiredRoles, subjectRoles, claims.Subject)
+				if err != nil {
+					forbidden(w, r, fmt.Errorf("%s: %w", descriptionFailedToValidateRoles, err))
+					return
+				}
+			}
 
 			// Serve next handler.
 			nextHandler.ServeHTTP(w, r)

--- a/server/internal/authz/middleware.go
+++ b/server/internal/authz/middleware.go
@@ -1,0 +1,54 @@
+package authz
+
+import "net/http"
+
+// ErrorHandlerFunc defines the function to handle an error in the middleware.
+type ErrorHandlerFunc func(w http.ResponseWriter, r *http.Request, err error)
+
+// MiddlewareOptions defines the middleware options structure.
+type MiddlewareOptions struct {
+	UnauthorizedHandlerFunc        ErrorHandlerFunc
+	ForbiddenHandlerFunc           ErrorHandlerFunc
+	InternalServerErrorHandlerFunc ErrorHandlerFunc
+}
+
+// Middleware validates the JWT in the Authorization header and ensures that the associated subject has the necessary
+// roles to access an endpoint based on the configured Roles.
+func (s *service) Middleware(options MiddlewareOptions) func(http.Handler) http.Handler {
+	unauthorized := options.UnauthorizedHandlerFunc
+	if unauthorized == nil {
+		unauthorized = func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, err.Error(), http.StatusUnauthorized)
+		}
+	}
+
+	forbidden := options.ForbiddenHandlerFunc
+	if forbidden == nil {
+		forbidden = func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+		}
+	}
+
+	internalServerError := options.InternalServerErrorHandlerFunc
+	if internalServerError == nil {
+		internalServerError = func(w http.ResponseWriter, r *http.Request, err error) {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}
+
+	return func(nextHandler http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// TODO: use option errors
+			// TODO: Authorization: Bearer <token>
+			// TODO: validate jwt
+			// TODO: fail if role map do not contain pattern
+			// TODO: don't validate roles for empty
+			// TODO: guarantee contain necessary roles
+			// TODO: admin early return in validation
+			// TODO: guarantee non-admin contains the same id as the one defined
+
+			// Serve next handler.
+			nextHandler.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/internal/domain/employee.go
+++ b/server/internal/domain/employee.go
@@ -12,14 +12,36 @@ var (
 	ErrEmployeeNotFound = errors.New("employee not found") // Returned when an employee is not found.
 )
 
+// EmployeeRole defines the role of the employee.
+type EmployeeRole string
+
+const (
+	EmployeeRoleWasteOperator EmployeeRole = "waste_operator"
+	EmployeeRoleManager       EmployeeRole = "manager"
+)
+
 // EditableEmployee defines the editable employee structure.
 type EditableEmployee struct {
-	Name        string
-	DateOfBirth time.Time
+	FirstName     string
+	LastName      string
+	Role          EmployeeRole
+	DateOfBirth   time.Time
+	PhoneNumber   string
+	Geom          string // Defined in the GeoJSON format.
+	ScheduleStart time.Time
+	ScheduleEnd   time.Time
 }
 
 // Employee defines the employee structure.
 type Employee struct {
 	EditableEmployee
-	ID uuid.UUID
+	ID           uuid.UUID
+	CreatedTime  time.Time
+	ModifiedTime time.Time
+}
+
+// EmployeeWithSignIn defines the employee with the sign-in structure.
+type EmployeeWithSignIn struct {
+	SignIn
+	Employee
 }

--- a/server/internal/logging/keys.go
+++ b/server/internal/logging/keys.go
@@ -6,6 +6,8 @@ const (
 	BuildTimestamp = "build.timestamp"
 	HostName       = "host.name"
 
+	ServiceMethod = "service.method"
+
 	EmployeeID       = "employee.id"
 	EmployeeUsername = "employee.username"
 )

--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -69,7 +69,7 @@ func (s *service) SignInEmployee(ctx context.Context, username string, password 
 		role = authn.SubjectRoleManager
 	}
 
-	token, err := s.authnService.NewJWT(employee.ID.String(), role)
+	token, err := s.authnService.NewJWT(employee.ID.String(), []authn.SubjectRole{role})
 	if err != nil {
 		return "", logAndWrapError(ctx, err, descriptionFailedCreateJWT, logAttrs...)
 	}

--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -69,7 +69,7 @@ func (s *service) SignInEmployee(ctx context.Context, username string, password 
 		role = authn.SubjectRoleManager
 	}
 
-	token, err := s.authnService.NewJWT(signIn.Username, role)
+	token, err := s.authnService.NewJWT(employee.ID.String(), role)
 	if err != nil {
 		return "", logAndWrapError(ctx, err, descriptionFailedCreateJWT, logAttrs...)
 	}

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -23,7 +23,7 @@ type AuthenticationService interface {
 	HashPassword(password string) (string, error)
 	CheckPasswordHash(password, hash string) (bool, error)
 
-	NewJWT(subject string, subjectRoles ...authn.SubjectRole) (string, error)
+	NewJWT(subject string, subjectRoles []authn.SubjectRole) (string, error)
 }
 
 // Store defines the store interface.

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -7,8 +7,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 
+	"github.com/goncalo-marques/ecomap/server/internal/authn"
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
 	"github.com/goncalo-marques/ecomap/server/internal/logging"
+)
+
+const (
+	descriptionFailedCheckPasswordHash = "service: failed to check password hash"
+	descriptionFailedCreateJWT         = "service: failed to create jwt"
 )
 
 // AuthenticationService defines the authentication service interface.
@@ -17,13 +23,13 @@ type AuthenticationService interface {
 	HashPassword(password string) (string, error)
 	CheckPasswordHash(password, hash string) (bool, error)
 
-	NewJWT(subject string) (string, error)
-	ParseJWT(tokenString string) (string, error)
+	NewJWT(subject string, subjectRoles ...authn.SubjectRole) (string, error)
 }
 
 // Store defines the store interface.
 type Store interface {
 	GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error)
+	GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.Employee, error)
 	GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error)
 
 	NewTx(ctx context.Context, isoLevel pgx.TxIsoLevel, accessMode pgx.TxAccessMode) (pgx.Tx, error)

--- a/server/internal/store/employee.go
+++ b/server/internal/store/employee.go
@@ -20,7 +20,7 @@ const (
 func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error) {
 	row := tx.QueryRow(ctx, `
 		SELECT username, password 
-		FROM public.employees 
+		FROM employees 
 		WHERE username = $1 
 	`, username)
 
@@ -45,7 +45,7 @@ func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username strin
 func (s *store) GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error) {
 	row := tx.QueryRow(ctx, `
 		SELECT id, name, date_of_birth
-		FROM public.employee
+		FROM employee
 		WHERE id = $1
 	`, id)
 

--- a/server/internal/store/employee.go
+++ b/server/internal/store/employee.go
@@ -11,11 +11,6 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
 )
 
-const (
-	descriptionFailedGetEmployeeSignIn = "store: failed to get employee sign-in"
-	descriptionFailedGetEmployeeByID   = "store: failed to get employee by id"
-)
-
 // GetEmployeeSignIn executes a query to return the sign-in of the employee with the specified username.
 func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error) {
 	row := tx.QueryRow(ctx, `
@@ -32,37 +27,90 @@ func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username strin
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedGetEmployeeSignIn, domain.ErrEmployeeNotFound)
+			return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, domain.ErrEmployeeNotFound)
 		}
 
-		return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedGetEmployeeSignIn, err)
+		return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, err)
 	}
 
 	return signIn, nil
 }
 
-// GetEmployeeByID executes a query to return the employee with the specified identifier.
-func (s *store) GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error) {
-	row := tx.QueryRow(ctx, `
-		SELECT id, name, date_of_birth
-		FROM employee
-		WHERE id = $1
-	`, id)
-
-	var employee domain.Employee
-
-	err := row.Scan(
-		&employee.ID,
-		&employee.Name,
-		&employee.DateOfBirth,
-	)
+// GetEmployeeByUsername executes a query to return the employee with the specified username.
+func (s *store) GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.Employee, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT id, first_name, last_name, role, date_of_birth, phone_number, ST_AsGeoJSON(geom), schedule_start, schedule_end, created_time, modified_time 
+		FROM employees 
+		WHERE username = $1 
+	`, username)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedGetEmployeeByID, domain.ErrEmployeeNotFound)
-		}
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
+	}
+	defer rows.Close()
 
-		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedGetEmployeeByID, err)
+	employees, err := getEmployeesFromRows(rows)
+	if err != nil {
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, err)
 	}
 
-	return employee, nil
+	if len(employees) == 0 {
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, domain.ErrEmployeeNotFound)
+	}
+
+	return employees[0], nil
+}
+
+// GetEmployeeByID executes a query to return the employee with the specified identifier.
+func (s *store) GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT id, first_name, last_name, role, date_of_birth, phone_number, ST_AsGeoJSON(geom), schedule_start, schedule_end, created_time, modified_time 
+		FROM employees 
+		WHERE id = $1 
+	`, id)
+	if err != nil {
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
+	}
+	defer rows.Close()
+
+	employees, err := getEmployeesFromRows(rows)
+	if err != nil {
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, err)
+	}
+
+	if len(employees) == 0 {
+		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, domain.ErrEmployeeNotFound)
+	}
+
+	return employees[0], nil
+}
+
+// getEmployeesFromRows returns the employees by scanning the given rows.
+func getEmployeesFromRows(rows pgx.Rows) ([]domain.Employee, error) {
+	var employees []domain.Employee
+	var err error
+
+	for rows.Next() {
+		var employee domain.Employee
+
+		err = rows.Scan(
+			&employee.ID,
+			&employee.FirstName,
+			&employee.LastName,
+			&employee.Role,
+			&employee.DateOfBirth,
+			&employee.PhoneNumber,
+			&employee.Geom,
+			&employee.ScheduleStart,
+			&employee.ScheduleEnd,
+			&employee.CreatedTime,
+			&employee.ModifiedTime,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		employees = append(employees, employee)
+	}
+
+	return employees, nil
 }

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -15,6 +15,13 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/store/tx"
 )
 
+// Common failure descriptions.
+const (
+	descriptionFailedQuery    = "store: failed to query"
+	descriptionFailedScanRow  = "store: failed to scan row"
+	descriptionFailedScanRows = "store: failed to scan rows"
+)
+
 // migrationsURL defines the source url of the migrations.
 const migrationsURL = "file://database/migrations"
 

--- a/server/internal/transport/http/authz.go
+++ b/server/internal/transport/http/authz.go
@@ -1,0 +1,32 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/goncalo-marques/ecomap/server/internal/authn"
+	"github.com/goncalo-marques/ecomap/server/internal/authz"
+)
+
+// API roles.
+const (
+	roleUser          = string(authn.SubjectRoleUser)
+	roleWasteOperator = string(authn.SubjectRoleWasteOperator)
+	roleManager       = string(authn.SubjectRoleManager)
+)
+
+// authzRoleMap defines the authorization role map for the API.
+var authzRoleMap authz.RoleMap = authz.RoleMap{
+	"/api/employees/signin": {
+		http.MethodPost: []string{},
+	},
+	"/api/employees/{employeeId}": {
+		http.MethodPost: []string{roleWasteOperator, roleManager},
+	},
+}
+
+// AuthzRoles defines the authorization roles for the API.
+var AuthzRoles authz.Roles = authz.Roles{
+	RoleMap:        authzRoleMap,
+	AuthzWildcards: []string{"{employeeId}", "{userId}"},
+	AdminRole:      roleManager,
+}

--- a/server/internal/transport/http/authz.go
+++ b/server/internal/transport/http/authz.go
@@ -1,8 +1,6 @@
 package http
 
 import (
-	"net/http"
-
 	"github.com/goncalo-marques/ecomap/server/internal/authn"
 	"github.com/goncalo-marques/ecomap/server/internal/authz"
 )
@@ -14,19 +12,8 @@ const (
 	roleManager       = string(authn.SubjectRoleManager)
 )
 
-// authzRoleMap defines the authorization role map for the API.
-var authzRoleMap authz.RoleMap = authz.RoleMap{
-	"/api/employees/signin": {
-		http.MethodPost: []string{},
-	},
-	"/api/employees/{employeeId}": {
-		http.MethodPost: []string{roleWasteOperator, roleManager},
-	},
-}
-
 // AuthzRoles defines the authorization roles for the API.
 var AuthzRoles authz.Roles = authz.Roles{
-	RoleMap:        authzRoleMap,
-	AuthzWildcards: []string{"{employeeId}", "{userId}"},
+	AuthzWildcards: []string{"employeeId", "userId"},
 	AdminRole:      roleManager,
 }

--- a/server/internal/transport/http/authz.go
+++ b/server/internal/transport/http/authz.go
@@ -5,15 +5,8 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/authz"
 )
 
-// API roles.
-const (
-	roleUser          = string(authn.SubjectRoleUser)
-	roleWasteOperator = string(authn.SubjectRoleWasteOperator)
-	roleManager       = string(authn.SubjectRoleManager)
-)
-
 // AuthzRoles defines the authorization roles for the API.
 var AuthzRoles authz.Roles = authz.Roles{
 	AuthzWildcards: []string{"employeeId", "userId"},
-	AdminRole:      roleManager,
+	AdminRole:      string(authn.SubjectRoleManager),
 }

--- a/server/internal/transport/http/fault.go
+++ b/server/internal/transport/http/fault.go
@@ -15,7 +15,8 @@ const (
 
 // Common fault descriptions.
 const (
-	descriptionFailedToMarshalResponseBody = "http: failed to marshal response body"
+	descriptionFailedToExecuteAuthorizationMiddleware = "http: failed to execute authorization middleware"
+	descriptionFailedToMarshalResponseBody            = "http: failed to marshal response body"
 )
 
 // badRequest writes an error response and sets the header with the bad request status code.

--- a/server/internal/transport/http/fault.go
+++ b/server/internal/transport/http/fault.go
@@ -15,8 +15,7 @@ const (
 
 // Common fault descriptions.
 const (
-	descriptionFailedToExecuteAuthorizationMiddleware = "http: failed to execute authorization middleware"
-	descriptionFailedToMarshalResponseBody            = "http: failed to marshal response body"
+	descriptionFailedToMarshalResponseBody = "http: failed to marshal response body"
 )
 
 // badRequest writes an error response and sets the header with the bad request status code.

--- a/server/internal/transport/http/fault.go
+++ b/server/internal/transport/http/fault.go
@@ -28,6 +28,11 @@ func unauthorized(w http.ResponseWriter, message string) {
 	_ = fault(w, http.StatusUnauthorized, spec.ErrorCodeUnauthorized, &message)
 }
 
+// forbidden writes an error response and sets the header with the forbidden status code.
+func forbidden(w http.ResponseWriter, message string) {
+	_ = fault(w, http.StatusForbidden, spec.ErrorCodeForbidden, &message)
+}
+
 // notFound writes an error response and sets the header with the not found status code.
 func notFound(w http.ResponseWriter, message string) {
 	_ = fault(w, http.StatusNotFound, spec.ErrorCodeNotFound, &message)

--- a/server/internal/transport/http/handler.go
+++ b/server/internal/transport/http/handler.go
@@ -13,7 +13,6 @@ import (
 	spec "github.com/goncalo-marques/ecomap/server/api/ecomap"
 	"github.com/goncalo-marques/ecomap/server/internal/authz"
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
-	"github.com/goncalo-marques/ecomap/server/internal/logging"
 )
 
 // Base URL const.
@@ -36,6 +35,7 @@ const (
 	requestHeaderValueAcceptHTML = "text/html"
 
 	errAuthorizationHeaderInvalid = "invalid authorization header"
+	errJWTInvalid                 = "invalid jwt"
 	errRolesInvalid               = "invalid subject roles"
 	errAuthorizationInvalid       = "unauthorized subject"
 	errParamInvalidFormat         = "invalid parameter format"
@@ -87,6 +87,8 @@ func New(authzService AuthorizationService, service Service) *handler {
 			switch {
 			case errors.Is(err, authz.ErrAuthorizationHeaderInvalid):
 				unauthorized(w, errAuthorizationHeaderInvalid)
+			case errors.Is(err, authz.ErrJWTInvalid):
+				unauthorized(w, errJWTInvalid)
 			default:
 				unauthorized(w, err.Error())
 			}
@@ -100,10 +102,6 @@ func New(authzService AuthorizationService, service Service) *handler {
 			default:
 				forbidden(w, err.Error())
 			}
-		},
-		InternalServerErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
-			logging.Logger.ErrorContext(r.Context(), descriptionFailedToExecuteAuthorizationMiddleware, logging.Error(err))
-			internalServerError(w)
 		},
 	})
 

--- a/server/internal/transport/http/mapper.go
+++ b/server/internal/transport/http/mapper.go
@@ -20,7 +20,7 @@ func jwtFromJWTToken(token string) spec.JWT {
 func employeeFromDomain(employee domain.Employee) spec.Employee {
 	return spec.Employee{
 		Id:          employee.ID,
-		Name:        employee.Name,
+		Name:        employee.FirstName,
 		DateOfBirth: dateFromTime(employee.DateOfBirth),
 	}
 }


### PR DESCRIPTION
Refs: closes #46 

## Summary

Add an authorization middleware for the employees and users based on their role.

## Changes

- Add bearer auth scopes in the swagger spec
- Add forbidden error code in the swagger spec
- Add subject roles to JWT claims
- Add authorization middleware
- Add service method logging key
- Add store method to get employee by username
- Update employee domain structure
- Update sign in employee service method to create and return JWT
- Remove `public.` prefix from database migrations
- Remove redundant token validation after parsing the JWT
