### PR TITLE
feat: add user sign in endpoint

### DIFF
--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -3,6 +3,7 @@ info:
   version: 1.0.0
   title: EcoMap Rest API
 tags:
+  - name: User
   - name: Employee
 servers:
   - url: https://server-7fzc7ivuwa-ew.a.run.app/api
@@ -11,6 +12,41 @@ servers:
     description: Local server.
 
 paths:
+  /users/signin:
+    post:
+      summary: Sign in a user.
+      operationId: signInUser
+      description: Returns a JSON Web Token for the specified username and password.
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SignIn"
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JWT"
+        400:
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          description: Incorrect credentials.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+
   /employees/signin:
     post:
       summary: Sign in an employee.

--- a/server/internal/domain/employee.go
+++ b/server/internal/domain/employee.go
@@ -39,9 +39,3 @@ type Employee struct {
 	CreatedTime  time.Time
 	ModifiedTime time.Time
 }
-
-// EmployeeWithSignIn defines the employee with the sign-in structure.
-type EmployeeWithSignIn struct {
-	SignIn
-	Employee
-}

--- a/server/internal/domain/user.go
+++ b/server/internal/domain/user.go
@@ -1,0 +1,27 @@
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// User errors.
+var (
+	ErrUserNotFound = errors.New("user not found") // Returned when a user is not found.
+)
+
+// EditableUser defines the editable user structure.
+type EditableUser struct {
+	FirstName string
+	LastName  string
+}
+
+// User defines the user structure.
+type User struct {
+	EditableUser
+	ID           uuid.UUID
+	CreatedTime  time.Time
+	ModifiedTime time.Time
+}

--- a/server/internal/logging/keys.go
+++ b/server/internal/logging/keys.go
@@ -8,6 +8,8 @@ const (
 
 	ServiceMethod = "service.method"
 
+	UserUsername = "user.username"
+
 	EmployeeID       = "employee.id"
 	EmployeeUsername = "employee.username"
 )

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -28,6 +28,9 @@ type AuthenticationService interface {
 
 // Store defines the store interface.
 type Store interface {
+	GetUserSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error)
+	GetUserByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.User, error)
+
 	GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error)
 	GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.Employee, error)
 	GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error)

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/goncalo-marques/ecomap/server/internal/authn"
+	"github.com/goncalo-marques/ecomap/server/internal/domain"
+	"github.com/goncalo-marques/ecomap/server/internal/logging"
+)
+
+const (
+	descriptionFailedGetUserSignIn     = "service: failed to get user sign-in"
+	descriptionFailedGetUserByUsername = "service: failed to get user by username"
+)
+
+// SignInUser returns a JSON Web Token for the specified username and password.
+func (s *service) SignInUser(ctx context.Context, username string, password string) (string, error) {
+	logAttrs := []any{
+		slog.String(logging.ServiceMethod, "SignInUser"),
+		slog.String(logging.UserUsername, username),
+	}
+
+	var signIn domain.SignIn
+	var err error
+
+	err = s.readOnlyTx(ctx, func(tx pgx.Tx) error {
+		signIn, err = s.store.GetUserSignIn(ctx, tx, username)
+		return err
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrUserNotFound):
+			return "", logInfoAndWrapError(ctx, domain.ErrCredentialsIncorrect, descriptionFailedGetUserSignIn, logAttrs...)
+		default:
+			return "", logAndWrapError(ctx, err, descriptionFailedGetUserSignIn, logAttrs...)
+		}
+	}
+
+	valid, err := s.authnService.CheckPasswordHash(password, signIn.Password)
+	if err != nil {
+		return "", logAndWrapError(ctx, err, descriptionFailedCheckPasswordHash, logAttrs...)
+	}
+
+	if !valid {
+		return "", logInfoAndWrapError(ctx, domain.ErrCredentialsIncorrect, descriptionFailedCheckPasswordHash, logAttrs...)
+	}
+
+	var user domain.User
+
+	err = s.readOnlyTx(ctx, func(tx pgx.Tx) error {
+		user, err = s.store.GetUserByUsername(ctx, tx, username)
+		return err
+	})
+	if err != nil {
+		return "", logAndWrapError(ctx, err, descriptionFailedGetUserByUsername, logAttrs...)
+	}
+
+	role := authn.SubjectRoleUser
+	token, err := s.authnService.NewJWT(user.ID.String(), []authn.SubjectRole{role})
+	if err != nil {
+		return "", logAndWrapError(ctx, err, descriptionFailedCreateJWT, logAttrs...)
+	}
+
+	return token, nil
+}

--- a/server/internal/store/user.go
+++ b/server/internal/store/user.go
@@ -1,0 +1,85 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/goncalo-marques/ecomap/server/internal/domain"
+)
+
+// GetUserSignIn executes a query to return the sign-in of the user with the specified username.
+func (s *store) GetUserSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error) {
+	row := tx.QueryRow(ctx, `
+		SELECT username, password 
+		FROM users 
+		WHERE username = $1 
+	`, username)
+
+	var signIn domain.SignIn
+
+	err := row.Scan(
+		&signIn.Username,
+		&signIn.Password,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, domain.ErrUserNotFound)
+		}
+
+		return domain.SignIn{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, err)
+	}
+
+	return signIn, nil
+}
+
+// GetUserByUsername executes a query to return the user with the specified username.
+func (s *store) GetUserByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.User, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT id, first_name, last_name, created_time, modified_time 
+		FROM users 
+		WHERE username = $1 
+	`, username)
+	if err != nil {
+		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
+	}
+	defer rows.Close()
+
+	users, err := getUsersFromRows(rows)
+	if err != nil {
+		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, err)
+	}
+
+	if len(users) == 0 {
+		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, domain.ErrUserNotFound)
+	}
+
+	return users[0], nil
+}
+
+// getUsersFromRows returns the users by scanning the given rows.
+func getUsersFromRows(rows pgx.Rows) ([]domain.User, error) {
+	var users []domain.User
+	var err error
+
+	for rows.Next() {
+		var user domain.User
+
+		err = rows.Scan(
+			&user.ID,
+			&user.FirstName,
+			&user.LastName,
+			&user.CreatedTime,
+			&user.ModifiedTime,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		users = append(users, user)
+	}
+
+	return users, nil
+}

--- a/server/internal/transport/http/handler.go
+++ b/server/internal/transport/http/handler.go
@@ -48,6 +48,8 @@ type AuthorizationService interface {
 
 // Service defines the service interface.
 type Service interface {
+	SignInUser(ctx context.Context, username string, password string) (string, error)
+
 	SignInEmployee(ctx context.Context, username string, password string) (string, error)
 	GetEmployeeByID(ctx context.Context, id uuid.UUID) (domain.Employee, error)
 }

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -1,0 +1,53 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	spec "github.com/goncalo-marques/ecomap/server/api/ecomap"
+	"github.com/goncalo-marques/ecomap/server/internal/domain"
+	"github.com/goncalo-marques/ecomap/server/internal/logging"
+)
+
+// SignInUser handles the http request to sign in a user.
+func (h *handler) SignInUser(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	requestBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		badRequest(w, errRequestBodyInvalid)
+		return
+	}
+
+	var signIn spec.SignIn
+	err = json.Unmarshal(requestBody, &signIn)
+	if err != nil {
+		badRequest(w, errRequestBodyInvalid)
+		return
+	}
+
+	token, err := h.service.SignInUser(ctx, signIn.Username, signIn.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrCredentialsIncorrect):
+			unauthorized(w, errIncorrectCredentials)
+		default:
+			internalServerError(w)
+		}
+
+		return
+	}
+
+	jwt := jwtFromJWTToken(token)
+
+	responseBody, err := json.Marshal(jwt)
+	if err != nil {
+		logging.Logger.ErrorContext(ctx, descriptionFailedToMarshalResponseBody, logging.Error(err))
+		internalServerError(w)
+		return
+	}
+
+	writeResponseJSON(w, http.StatusOK, responseBody)
+}


### PR DESCRIPTION
Refs: closes #47 

## Summary

Add endpoint to sign a user in and return a JWT.

## Changes

- Add user sign in endpoint to swagger spec
- Add domain user models
- Add domain error for users not found
- Add user username logging key
- Add http transport layer to handle user sign in
- Add service layer to handle user sign in
- Add store layer to handle user sign in
- Remove unnecessary domain employee model
