### PR TITLE
feat: add endpoint to create user

### DIFF
--- a/cspell.yml
+++ b/cspell.yml
@@ -29,6 +29,7 @@ ignoreWords:
   - oapitypes
   - openapi
   - Parens
+  - pgconn
   - pgrouting
   - PGUSER
   - pgxpool

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -12,6 +12,259 @@ servers:
     description: Local server.
 
 paths:
+  /users:
+    post:
+      summary: Create a user.
+      operationId: createUser
+      description: Creates a new user with the specified data.
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserPost"
+      responses:
+        201:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        400:
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        409:
+          description: Username already exists.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+    get:
+      summary: List users.
+      operationId: listUsers
+      description: Returns the users with the specified filter.
+      tags:
+        - User
+      security:
+        - BearerAuth: [manager]
+      parameters:
+        - $ref: "#/components/parameters/LimitQueryParam"
+        - $ref: "#/components/parameters/OffsetQueryParam"
+        - $ref: "#/components/parameters/SortQueryParam"
+        - $ref: "#/components/parameters/OrderQueryParam"
+        - name: username
+          in: query
+          description: Username to filter by.
+          schema:
+            type: string
+        - name: firstName
+          in: query
+          description: First name to filter by.
+          schema:
+            type: string
+        - name: lastName
+          in: query
+          description: Last name to filter by.
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsersPaginated"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+  /users/{userId}:
+    get:
+      summary: Get a user by ID.
+      operationId: getUserByID
+      description: Returns the user with the specified identifier.
+      tags:
+        - User
+      security:
+        - BearerAuth: [user, manager]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPathParam"
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        400:
+          description: Invalid user ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+    patch:
+      summary: Modify a user by ID.
+      operationId: patchUserByID
+      description: Modifies the user with the specified identifier. Only the specified fields in the request body are updated.
+      tags:
+        - User
+      security:
+        - BearerAuth: [user, manager]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPathParam"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserPatch"
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        400:
+          description: Invalid user ID or request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      summary: Delete a user by ID.
+      operationId: deleteUserByID
+      description: Deletes the user with the specified identifier.
+      tags:
+        - User
+      security:
+        - BearerAuth: [user, manager]
+      parameters:
+        - $ref: "#/components/parameters/UserIdPathParam"
+      responses:
+        200:
+          description: Successful operation.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        400:
+          description: Invalid user ID.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+  /users/password:
+    put:
+      summary: Update a user password.
+      operationId: updateUserPassword
+      description: Updates the password of the user with the specified username.
+      tags:
+        - User
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordChange"
+      responses:
+        204:
+          description: Successful operation.
+        400:
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          description: Incorrect credentials.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
+  /users/reset-password:
+    put:
+      summary: Reset a user password.
+      operationId: resetUserPassword
+      description: Resets the password of the user with the specified username.
+      tags:
+        - User
+      security:
+        - BearerAuth: [manager]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PasswordReset"
+      responses:
+        204:
+          description: Successful operation.
+        400:
+          description: Invalid request body.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          description: User not found.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        500:
+          $ref: "#/components/responses/InternalServerError"
   /users/signin:
     post:
       summary: Sign in a user.
@@ -91,7 +344,7 @@ paths:
       security:
         - BearerAuth: [waste_operator, manager]
       parameters:
-        - $ref: "#/components/parameters/EmployeeIdParam"
+        - $ref: "#/components/parameters/EmployeeIdPathParam"
       responses:
         200:
           description: Successful operation.
@@ -126,7 +379,49 @@ components:
       bearerFormat: JWT
 
   parameters:
-    EmployeeIdParam:
+    LimitQueryParam:
+      name: limit
+      in: query
+      description: Amount of resources to get for the provided filter.
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 100
+    OffsetQueryParam:
+      name: offset
+      in: query
+      description: Amount of resources to skip for the provided filter.
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    SortQueryParam:
+      name: sort
+      in: query
+      description: Name of the field to sort by.
+      schema:
+        type: string
+        example: username
+    OrderQueryParam:
+      name: order
+      in: query
+      description: Order to sort by.
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: asc
+
+    UserIdPathParam:
+      name: userId
+      in: path
+      description: User identifier.
+      required: true
+      schema:
+        $ref: "#/components/schemas/UUID"
+    EmployeeIdPathParam:
       name: employeeId
       in: path
       description: Employee identifier.
@@ -135,10 +430,6 @@ components:
         $ref: "#/components/schemas/UUID"
 
   schemas:
-    UUID:
-      type: string
-      format: uuid
-      example: "9e3a65b0-0579-4203-8112-d09ab3c6b1ff"
     Error:
       type: object
       required:
@@ -154,6 +445,34 @@ components:
             - internal_server_error
         message:
           type: string
+    UUID:
+      type: string
+      format: uuid
+      example: "9e3a65b0-0579-4203-8112-d09ab3c6b1ff"
+    Date:
+      type: string
+      format: date
+      example: "2017-07-21"
+    DateTime:
+      type: string
+      format: date-time
+      example: "2017-07-21T17:32:28Z"
+    Username:
+      type: string
+      minLength: 1
+      maxLength: 50
+      example: john-doe
+    Password:
+      type: string
+      description: In addition to the length restrictions, the password should contain at least one regular character, one special character, and one number.
+      minLength: 14
+      maxLength: 72
+      example: ReallySecurePassword$123
+    Name:
+      type: string
+      minLength: 1
+      maxLength: 50
+      example: John
 
     SignIn:
       type: object
@@ -162,9 +481,9 @@ components:
         - password
       properties:
         username:
-          type: string
+          $ref: "#/components/schemas/Username"
         password:
-          type: string
+          $ref: "#/components/schemas/Password"
     JWT:
       type: object
       required:
@@ -173,6 +492,97 @@ components:
         token:
           type: string
           example: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVcJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiWiBmFtZSI6IkPvaG4gRG9lIiWiaWF0IjOxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssW5c
+    PasswordChange:
+      type: object
+      required:
+        - username
+        - oldPassword
+        - newPassword
+      properties:
+        username:
+          $ref: "#/components/schemas/Username"
+        oldPassword:
+          $ref: "#/components/schemas/Password"
+        newPassword:
+          $ref: "#/components/schemas/Password"
+    PasswordReset:
+      type: object
+      required:
+        - username
+        - newPassword
+      properties:
+        username:
+          $ref: "#/components/schemas/Username"
+        newPassword:
+          $ref: "#/components/schemas/Password"
+    PaginatedResponse:
+      type: object
+      required:
+        - total
+      properties:
+        total:
+          type: integer
+          description: The total amount of resources available for the provided filter.
+          minimum: 0
+
+    UserPost:
+      type: object
+      required:
+        - username
+        - password
+        - firstName
+        - lastName
+      properties:
+        username:
+          $ref: "#/components/schemas/Username"
+        password:
+          $ref: "#/components/schemas/Password"
+        firstName:
+          $ref: "#/components/schemas/Name"
+        lastName:
+          $ref: "#/components/schemas/Name"
+    UserPatch:
+      type: object
+      properties:
+        username:
+          $ref: "#/components/schemas/Username"
+        firstName:
+          $ref: "#/components/schemas/Name"
+        lastName:
+          $ref: "#/components/schemas/Name"
+    User:
+      type: object
+      required:
+        - id
+        - username
+        - firstName
+        - lastName
+        - createdTime
+        - modifiedTime
+      properties:
+        id:
+          $ref: "#/components/schemas/UUID"
+        username:
+          $ref: "#/components/schemas/Username"
+        firstName:
+          $ref: "#/components/schemas/Name"
+        lastName:
+          $ref: "#/components/schemas/Name"
+        createdTime:
+          $ref: "#/components/schemas/DateTime"
+        modifiedTime:
+          $ref: "#/components/schemas/DateTime"
+    UsersPaginated:
+      allOf:
+        - $ref: "#/components/schemas/PaginatedResponse"
+        - type: object
+          required:
+            - users
+          properties:
+            users:
+              type: array
+              items:
+                $ref: "#/components/schemas/User"
 
     EditableEmployee:
       type: object
@@ -184,9 +594,7 @@ components:
           type: string
           example: "John Doe"
         dateOfBirth:
-          type: string
-          format: date
-          example: "2006-01-02"
+          $ref: "#/components/schemas/Date"
     Employee:
       allOf:
         - $ref: "#/components/schemas/EditableEmployee"

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -448,6 +448,7 @@ components:
             - unauthorized
             - forbidden
             - not_found
+            - conflict
             - internal_server_error
         message:
           type: string

--- a/server/internal/authn/password.go
+++ b/server/internal/authn/password.go
@@ -9,37 +9,47 @@ import (
 
 const (
 	passwordMinLength       = 14
+	passwordMaxLength       = 72
 	passwordMinDigits       = 1
+	passwordMinChars        = 1
 	passwordMinSpecialChars = 1
 )
 
 // ValidPassword returns true if the password matches the requirements, false otherwise.
-func (s *service) ValidPassword(password string) bool {
+func (s *service) ValidPassword(password []byte) bool {
+	// Check password length requirements.
+	if len(password) < passwordMinLength || len(password) > passwordMaxLength {
+		return false
+	}
+
+	// Check password complexity requirements.
 	var digits int
+	var chars int
 	var specialChars int
-	for _, r := range password {
+	for _, r := range string(password) {
 		if unicode.IsDigit(r) {
 			digits++
 			continue
 		}
-		if !unicode.IsLetter(r) {
+		if unicode.IsLetter(r) {
+			chars++
+		} else {
 			specialChars++
-			continue
 		}
 	}
 
-	return len(password) >= passwordMinLength && digits >= passwordMinDigits && specialChars >= passwordMinSpecialChars
+	return digits >= passwordMinDigits && chars >= passwordMinChars && specialChars >= passwordMinSpecialChars
 }
 
 // HashPassword returns the hashed password.
-func (s *service) HashPassword(password string) (string, error) {
-	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	return string(bytes), err
+func (s *service) HashPassword(password []byte) ([]byte, error) {
+	bytes, err := bcrypt.GenerateFromPassword(password, bcrypt.DefaultCost)
+	return bytes, err
 }
 
 // CheckPasswordHash returns true if the password matches the hashed password, false otherwise.
-func (s *service) CheckPasswordHash(password, hash string) (bool, error) {
-	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+func (s *service) CheckPasswordHash(password, hash []byte) (bool, error) {
+	err := bcrypt.CompareHashAndPassword(hash, password)
 	if err != nil {
 		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
 			return false, nil

--- a/server/internal/domain/common.go
+++ b/server/internal/domain/common.go
@@ -11,12 +11,12 @@ var (
 )
 
 // Returned when a field contains an invalid value.
-type ErrFieldInvalid struct {
+type ErrFieldValueInvalid struct {
 	FieldName string
 }
 
-func (e *ErrFieldInvalid) Error() string {
-	return fmt.Sprintf("invalid field: %s", e.FieldName)
+func (e *ErrFieldValueInvalid) Error() string {
+	return fmt.Sprintf("invalid field value: %s", e.FieldName)
 }
 
 // Field constraints.

--- a/server/internal/domain/common.go
+++ b/server/internal/domain/common.go
@@ -2,6 +2,7 @@ package domain
 
 import (
 	"errors"
+	"fmt"
 )
 
 // Common errors.
@@ -9,8 +10,45 @@ var (
 	ErrCredentialsIncorrect = errors.New("incorrect credentials") // Returned when a username is not found or the password is incorrect.
 )
 
+// Returned when a field contains an invalid value.
+type ErrFieldInvalid struct {
+	FieldName string
+}
+
+func (e *ErrFieldInvalid) Error() string {
+	return fmt.Sprintf("invalid field: %s", e.FieldName)
+}
+
+// Field constraints.
+const (
+	usernameMinLength = 1
+	usernameMaxLength = 50
+
+	nameMinLength = 1
+	nameMaxLength = 50
+)
+
+// Username defines the username type.
+type Username string
+
+// Valid returns true if the username is valid, false otherwise.
+func (u Username) Valid() bool {
+	return len(u) >= usernameMinLength && len(u) <= usernameMaxLength
+}
+
+// Name defines the name type.
+type Name string
+
+// Valid returns true if the name is valid, false otherwise.
+func (n Name) Valid() bool {
+	return len(n) >= nameMinLength && len(n) <= nameMaxLength
+}
+
+// Password defines the password type.
+type Password string
+
 // SignIn defines the sign-in structure.
 type SignIn struct {
-	Username string
-	Password string
+	Username Username
+	Password Password
 }

--- a/server/internal/domain/employee.go
+++ b/server/internal/domain/employee.go
@@ -22,8 +22,8 @@ const (
 
 // EditableEmployee defines the editable employee structure.
 type EditableEmployee struct {
-	FirstName     string
-	LastName      string
+	FirstName     Name
+	LastName      Name
 	Role          EmployeeRole
 	DateOfBirth   time.Time
 	PhoneNumber   string

--- a/server/internal/domain/user.go
+++ b/server/internal/domain/user.go
@@ -9,13 +9,28 @@ import (
 
 // User errors.
 var (
-	ErrUserNotFound = errors.New("user not found") // Returned when a user is not found.
+	ErrUserAlreadyExists = errors.New("username already exists") // Returned when a user already exists with the same username.
+	ErrUserNotFound      = errors.New("user not found")          // Returned when a user is not found.
 )
 
 // EditableUser defines the editable user structure.
 type EditableUser struct {
-	FirstName string
-	LastName  string
+	Username  Username
+	FirstName Name
+	LastName  Name
+}
+
+// EditableUserWithPassword defines the editable user structure with a password.
+type EditableUserWithPassword struct {
+	EditableUser
+	Password
+}
+
+// EditableUserPatch defines the patchable user structure.
+type EditableUserPatch struct {
+	Username  *Username
+	FirstName *Name
+	LastName  *Name
 }
 
 // User defines the user structure.

--- a/server/internal/logging/keys.go
+++ b/server/internal/logging/keys.go
@@ -8,7 +8,9 @@ const (
 
 	ServiceMethod = "service.method"
 
-	UserUsername = "user.username"
+	UserUsername  = "user.username"
+	UserFirstName = "user.firstName"
+	UserLastName  = "user.lastName"
 
 	EmployeeID       = "employee.id"
 	EmployeeUsername = "employee.username"

--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -42,7 +42,7 @@ func (s *service) SignInEmployee(ctx context.Context, username string, password 
 		}
 	}
 
-	valid, err := s.authnService.CheckPasswordHash(password, signIn.Password)
+	valid, err := s.authnService.CheckPasswordHash([]byte(password), []byte(signIn.Password))
 	if err != nil {
 		return "", logAndWrapError(ctx, err, descriptionFailedCheckPasswordHash, logAttrs...)
 	}

--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -14,16 +14,16 @@ import (
 )
 
 const (
-	descriptionFailedGetEmployeeSignIn     = "service: failed to get employee sign-in"
-	descriptionFailedGetEmployeeByUsername = "service: failed to get employee by username"
 	descriptionFailedGetEmployeeByID       = "service: failed to get employee by id"
+	descriptionFailedGetEmployeeByUsername = "service: failed to get employee by username"
+	descriptionFailedGetEmployeeSignIn     = "service: failed to get employee sign-in"
 )
 
 // SignInEmployee returns a JSON Web Token for the specified username and password.
-func (s *service) SignInEmployee(ctx context.Context, username string, password string) (string, error) {
+func (s *service) SignInEmployee(ctx context.Context, username domain.Username, password string) (string, error) {
 	logAttrs := []any{
 		slog.String(logging.ServiceMethod, "SignInEmployee"),
-		slog.String(logging.EmployeeUsername, username),
+		slog.String(logging.EmployeeUsername, string(username)),
 	}
 
 	var signIn domain.SignIn

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -13,6 +14,13 @@ import (
 )
 
 const (
+	fieldUsername  = "username"
+	fieldPassword  = "password"
+	fieldFirstName = "firstName"
+	fieldLastName  = "lastName"
+
+	descriptionInvalidField            = "service: invalid field"
+	descriptionFailedHashPassword      = "service: failed to hash password"
 	descriptionFailedCheckPasswordHash = "service: failed to check password hash"
 	descriptionFailedCreateJWT         = "service: failed to create jwt"
 )
@@ -28,11 +36,12 @@ type AuthenticationService interface {
 
 // Store defines the store interface.
 type Store interface {
-	GetUserSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error)
-	GetUserByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.User, error)
+	CreateUser(ctx context.Context, tx pgx.Tx, editableUser domain.EditableUserWithPassword) (domain.User, error)
+	GetUserSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error)
+	GetUserByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.User, error)
 
-	GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error)
-	GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.Employee, error)
+	GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error)
+	GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.Employee, error)
 	GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error)
 
 	NewTx(ctx context.Context, isoLevel pgx.TxIsoLevel, accessMode pgx.TxAccessMode) (pgx.Tx, error)
@@ -77,21 +86,20 @@ func (s *service) readOnlyTx(ctx context.Context, f func(pgx.Tx) error) error {
 	return tx.Commit(ctx)
 }
 
-// TODO: Avoid lint issue (remove this comments in the future)
 // readWriteTx returns a read and write transaction wrapper.
-// func (s *service) readWriteTx(ctx context.Context, f func(pgx.Tx) error) error {
-// 	tx, err := s.store.NewTx(ctx, pgx.RepeatableRead, pgx.ReadWrite)
-// 	if err != nil {
-// 		return err
-// 	}
-// 	defer rollbackFunc(ctx, tx)()
+func (s *service) readWriteTx(ctx context.Context, f func(pgx.Tx) error) error {
+	tx, err := s.store.NewTx(ctx, pgx.RepeatableRead, pgx.ReadWrite)
+	if err != nil {
+		return err
+	}
+	defer rollbackFunc(ctx, tx)()
 
-// 	if err := f(tx); err != nil {
-// 		return err
-// 	}
+	if err := f(tx); err != nil {
+		return err
+	}
 
-// 	return tx.Commit(ctx)
-// }
+	return tx.Commit(ctx)
+}
 
 // logInfoAndWrapError logs the error at the info level and returns the error wrapped with the provided description.
 func logInfoAndWrapError(ctx context.Context, err error, description string, logAttrs ...any) error {
@@ -105,4 +113,9 @@ func logAndWrapError(ctx context.Context, err error, description string, logAttr
 	logAttrs = append(logAttrs, logging.Error(err))
 	logging.Logger.ErrorContext(ctx, description, logAttrs...)
 	return fmt.Errorf("%s: %w", description, err)
+}
+
+// replaceSpacesWithHyphen returns s with no extra spaces and separates it with a hyphen.
+func replaceSpacesWithHyphen(s string) string {
+	return strings.Join(strings.Fields(s), "-")
 }

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -19,9 +19,9 @@ const (
 
 // AuthenticationService defines the authentication service interface.
 type AuthenticationService interface {
-	ValidPassword(password string) bool
-	HashPassword(password string) (string, error)
-	CheckPasswordHash(password, hash string) (bool, error)
+	ValidPassword(password []byte) bool
+	HashPassword(password []byte) ([]byte, error)
+	CheckPasswordHash(password, hash []byte) (bool, error)
 
 	NewJWT(subject string, subjectRoles []authn.SubjectRole) (string, error)
 }

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -19,7 +19,7 @@ const (
 	fieldFirstName = "firstName"
 	fieldLastName  = "lastName"
 
-	descriptionInvalidField            = "service: invalid field"
+	descriptionInvalidFieldValue       = "service: invalid field value"
 	descriptionFailedHashPassword      = "service: failed to hash password"
 	descriptionFailedCheckPasswordHash = "service: failed to check password hash"
 	descriptionFailedCreateJWT         = "service: failed to create jwt"

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -32,16 +32,16 @@ func (s *service) CreateUser(ctx context.Context, editableUser domain.EditableUs
 	editableUser.LastName = domain.Name(replaceSpacesWithHyphen(string(editableUser.LastName)))
 
 	if !editableUser.Username.Valid() {
-		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldUsername}, descriptionInvalidField, logAttrs...)
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldUsername}, descriptionInvalidFieldValue, logAttrs...)
 	}
 	if !s.authnService.ValidPassword([]byte(editableUser.Password)) {
-		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldPassword}, descriptionInvalidField, logAttrs...)
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldPassword}, descriptionInvalidFieldValue, logAttrs...)
 	}
 	if !editableUser.FirstName.Valid() {
-		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldFirstName}, descriptionInvalidField, logAttrs...)
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldFirstName}, descriptionInvalidFieldValue, logAttrs...)
 	}
 	if !editableUser.LastName.Valid() {
-		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldLastName}, descriptionInvalidField, logAttrs...)
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldLastName}, descriptionInvalidFieldValue, logAttrs...)
 	}
 
 	hashedPassword, err := s.authnService.HashPassword([]byte(editableUser.Password))

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -13,15 +13,67 @@ import (
 )
 
 const (
-	descriptionFailedGetUserSignIn     = "service: failed to get user sign-in"
+	descriptionFailedCreateUser        = "service: failed to create user"
 	descriptionFailedGetUserByUsername = "service: failed to get user by username"
+	descriptionFailedGetUserSignIn     = "service: failed to get user sign-in"
 )
 
+// CreateUser creates a new user with the specified data.
+func (s *service) CreateUser(ctx context.Context, editableUser domain.EditableUserWithPassword) (domain.User, error) {
+	logAttrs := []any{
+		slog.String(logging.ServiceMethod, "CreateUser"),
+		slog.String(logging.UserUsername, string(editableUser.Username)),
+		slog.String(logging.UserFirstName, string(editableUser.FirstName)),
+		slog.String(logging.UserLastName, string(editableUser.LastName)),
+	}
+
+	editableUser.Username = domain.Username(replaceSpacesWithHyphen(string(editableUser.Username)))
+	editableUser.FirstName = domain.Name(replaceSpacesWithHyphen(string(editableUser.FirstName)))
+	editableUser.LastName = domain.Name(replaceSpacesWithHyphen(string(editableUser.LastName)))
+
+	if !editableUser.Username.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldUsername}, descriptionInvalidField, logAttrs...)
+	}
+	if !s.authnService.ValidPassword([]byte(editableUser.Password)) {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldPassword}, descriptionInvalidField, logAttrs...)
+	}
+	if !editableUser.FirstName.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldFirstName}, descriptionInvalidField, logAttrs...)
+	}
+	if !editableUser.LastName.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldInvalid{FieldName: fieldLastName}, descriptionInvalidField, logAttrs...)
+	}
+
+	hashedPassword, err := s.authnService.HashPassword([]byte(editableUser.Password))
+	if err != nil {
+		return domain.User{}, logAndWrapError(ctx, err, descriptionFailedHashPassword, logAttrs...)
+	}
+
+	editableUser.Password = domain.Password(hashedPassword)
+
+	var user domain.User
+
+	err = s.readWriteTx(ctx, func(tx pgx.Tx) error {
+		user, err = s.store.CreateUser(ctx, tx, editableUser)
+		return err
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrUserAlreadyExists):
+			return domain.User{}, logInfoAndWrapError(ctx, err, descriptionFailedCreateUser, logAttrs...)
+		default:
+			return domain.User{}, logAndWrapError(ctx, err, descriptionFailedCreateUser, logAttrs...)
+		}
+	}
+
+	return user, nil
+}
+
 // SignInUser returns a JSON Web Token for the specified username and password.
-func (s *service) SignInUser(ctx context.Context, username string, password string) (string, error) {
+func (s *service) SignInUser(ctx context.Context, username domain.Username, password string) (string, error) {
 	logAttrs := []any{
 		slog.String(logging.ServiceMethod, "SignInUser"),
-		slog.String(logging.UserUsername, username),
+		slog.String(logging.UserUsername, string(username)),
 	}
 
 	var signIn domain.SignIn

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -40,7 +40,7 @@ func (s *service) SignInUser(ctx context.Context, username string, password stri
 		}
 	}
 
-	valid, err := s.authnService.CheckPasswordHash(password, signIn.Password)
+	valid, err := s.authnService.CheckPasswordHash([]byte(password), []byte(signIn.Password))
 	if err != nil {
 		return "", logAndWrapError(ctx, err, descriptionFailedCheckPasswordHash, logAttrs...)
 	}

--- a/server/internal/store/employee.go
+++ b/server/internal/store/employee.go
@@ -11,16 +11,19 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
 )
 
+// TODO: Replicate User methods.
+
 // GetEmployeeSignIn executes a query to return the sign-in of the employee with the specified username.
-func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error) {
+func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error) {
 	row := tx.QueryRow(ctx, `
 		SELECT username, password 
 		FROM employees 
 		WHERE username = $1 
-	`, username)
+	`,
+		username,
+	)
 
 	var signIn domain.SignIn
-
 	err := row.Scan(
 		&signIn.Username,
 		&signIn.Password,
@@ -37,12 +40,14 @@ func (s *store) GetEmployeeSignIn(ctx context.Context, tx pgx.Tx, username strin
 }
 
 // GetEmployeeByUsername executes a query to return the employee with the specified username.
-func (s *store) GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.Employee, error) {
+func (s *store) GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.Employee, error) {
 	rows, err := tx.Query(ctx, `
 		SELECT id, first_name, last_name, role, date_of_birth, phone_number, ST_AsGeoJSON(geom), schedule_start, schedule_end, created_time, modified_time 
 		FROM employees 
 		WHERE username = $1 
-	`, username)
+	`,
+		username,
+	)
 	if err != nil {
 		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
 	}
@@ -66,7 +71,9 @@ func (s *store) GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (d
 		SELECT id, first_name, last_name, role, date_of_birth, phone_number, ST_AsGeoJSON(geom), schedule_start, schedule_end, created_time, modified_time 
 		FROM employees 
 		WHERE id = $1 
-	`, id)
+	`,
+		id,
+	)
 	if err != nil {
 		return domain.Employee{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
 	}

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/goncalo-marques/ecomap/server/internal/config"
@@ -64,4 +65,14 @@ func (s *store) NewTx(ctx context.Context, isoLevel pgx.TxIsoLevel, accessMode p
 // Close closes the database.
 func (s *store) Close() {
 	s.database.Close()
+}
+
+// getConstraintName returns the name of the constraint of the given error. If the error is not of type pgconn.PgError,
+// an empty string is returned.
+func getConstraintName(err error) string {
+	if pqErr, ok := err.(*pgconn.PgError); ok {
+		return pqErr.ConstraintName
+	}
+
+	return ""
 }

--- a/server/internal/store/user.go
+++ b/server/internal/store/user.go
@@ -10,16 +10,46 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
 )
 
+const (
+	constraintUsersUsernameKey = "users_username_key"
+)
+
+// CreateUser executes a query to create a user with the specified data.
+func (s *store) CreateUser(ctx context.Context, tx pgx.Tx, editableUser domain.EditableUserWithPassword) (domain.User, error) {
+	row := tx.QueryRow(ctx, `
+		INSERT INTO users (username, password, first_name, last_name)
+		VALUES ($1, $2, $3, $4) 
+		RETURNING id, username, first_name, last_name, created_time, modified_time
+	`,
+		editableUser.Username,
+		editableUser.Password,
+		editableUser.FirstName,
+		editableUser.LastName,
+	)
+
+	user, err := getUserFromRow(row)
+	if err != nil {
+		if getConstraintName(err) == constraintUsersUsernameKey {
+			return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, domain.ErrUserAlreadyExists)
+		}
+
+		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, err)
+	}
+
+	return user, nil
+}
+
 // GetUserSignIn executes a query to return the sign-in of the user with the specified username.
-func (s *store) GetUserSignIn(ctx context.Context, tx pgx.Tx, username string) (domain.SignIn, error) {
+func (s *store) GetUserSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error) {
 	row := tx.QueryRow(ctx, `
 		SELECT username, password 
 		FROM users 
 		WHERE username = $1 
-	`, username)
+	`,
+		username,
+	)
 
 	var signIn domain.SignIn
-
 	err := row.Scan(
 		&signIn.Username,
 		&signIn.Password,
@@ -36,50 +66,57 @@ func (s *store) GetUserSignIn(ctx context.Context, tx pgx.Tx, username string) (
 }
 
 // GetUserByUsername executes a query to return the user with the specified username.
-func (s *store) GetUserByUsername(ctx context.Context, tx pgx.Tx, username string) (domain.User, error) {
-	rows, err := tx.Query(ctx, `
-		SELECT id, first_name, last_name, created_time, modified_time 
+func (s *store) GetUserByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.User, error) {
+	row := tx.QueryRow(ctx, `
+		SELECT id, username, first_name, last_name, created_time, modified_time 
 		FROM users 
 		WHERE username = $1 
-	`, username)
+	`,
+		username,
+	)
+
+	user, err := getUserFromRow(row)
 	if err != nil {
-		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedQuery, err)
-	}
-	defer rows.Close()
-
-	users, err := getUsersFromRows(rows)
-	if err != nil {
-		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, err)
-	}
-
-	if len(users) == 0 {
-		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRows, domain.ErrUserNotFound)
-	}
-
-	return users[0], nil
-}
-
-// getUsersFromRows returns the users by scanning the given rows.
-func getUsersFromRows(rows pgx.Rows) ([]domain.User, error) {
-	var users []domain.User
-	var err error
-
-	for rows.Next() {
-		var user domain.User
-
-		err = rows.Scan(
-			&user.ID,
-			&user.FirstName,
-			&user.LastName,
-			&user.CreatedTime,
-			&user.ModifiedTime,
-		)
-		if err != nil {
-			return nil, err
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, domain.ErrUserNotFound)
 		}
 
-		users = append(users, user)
+		return domain.User{}, fmt.Errorf("%s: %w", descriptionFailedScanRow, err)
 	}
 
-	return users, nil
+	return user, nil
 }
+
+// getUserFromRow returns the user by scanning the given row.
+func getUserFromRow(row pgx.Row) (domain.User, error) {
+	var user domain.User
+	err := row.Scan(
+		&user.ID,
+		&user.Username,
+		&user.FirstName,
+		&user.LastName,
+		&user.CreatedTime,
+		&user.ModifiedTime,
+	)
+	if err != nil {
+		return domain.User{}, err
+	}
+
+	return user, nil
+}
+
+// TODO: Remove comments when necessary.
+// getUsersFromRows returns the users by scanning the given rows.
+// func getUsersFromRows(rows pgx.Rows) ([]domain.User, error) {
+// 	var users []domain.User
+// 	for rows.Next() {
+// 		user, err := getUserFromRow(rows)
+// 		if err != nil {
+// 			return nil, err
+// 		}
+
+// 		users = append(users, user)
+// 	}
+
+// 	return users, nil
+// }

--- a/server/internal/transport/http/employee.go
+++ b/server/internal/transport/http/employee.go
@@ -32,11 +32,11 @@ func (h *handler) SignInEmployee(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.service.SignInEmployee(ctx, signIn.Username, signIn.Password)
+	token, err := h.service.SignInEmployee(ctx, domain.Username(signIn.Username), signIn.Password)
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrCredentialsIncorrect):
-			unauthorized(w, errIncorrectCredentials)
+			unauthorized(w, errCredentialsIncorrect)
 		default:
 			internalServerError(w)
 		}
@@ -45,7 +45,6 @@ func (h *handler) SignInEmployee(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jwt := jwtFromJWTToken(token)
-
 	responseBody, err := json.Marshal(jwt)
 	if err != nil {
 		logging.Logger.ErrorContext(ctx, descriptionFailedToMarshalResponseBody, logging.Error(err))
@@ -73,7 +72,6 @@ func (h *handler) GetEmployeeByID(w http.ResponseWriter, r *http.Request, employ
 	}
 
 	employee := employeeFromDomain(domainEmployee)
-
 	responseBody, err := json.Marshal(employee)
 	if err != nil {
 		logging.Logger.ErrorContext(ctx, descriptionFailedToMarshalResponseBody, logging.Error(err))

--- a/server/internal/transport/http/employee.go
+++ b/server/internal/transport/http/employee.go
@@ -57,7 +57,7 @@ func (h *handler) SignInEmployee(w http.ResponseWriter, r *http.Request) {
 }
 
 // GetEmployeeByID handles the http request to get an employee by id.
-func (h *handler) GetEmployeeByID(w http.ResponseWriter, r *http.Request, employeeID spec.EmployeeIdParam) {
+func (h *handler) GetEmployeeByID(w http.ResponseWriter, r *http.Request, employeeID spec.EmployeeIdPathParam) {
 	ctx := r.Context()
 
 	domainEmployee, err := h.service.GetEmployeeByID(ctx, employeeID)

--- a/server/internal/transport/http/fault.go
+++ b/server/internal/transport/http/fault.go
@@ -10,7 +10,8 @@ import (
 // Common fault messages.
 const (
 	errRequestBodyInvalid   = "invalid request body"
-	errIncorrectCredentials = "incorrect credentials"
+	errFieldInvalid         = "invalid field"
+	errCredentialsIncorrect = "incorrect credentials"
 )
 
 // Common fault descriptions.
@@ -36,6 +37,11 @@ func forbidden(w http.ResponseWriter, message string) {
 // notFound writes an error response and sets the header with the not found status code.
 func notFound(w http.ResponseWriter, message string) {
 	_ = fault(w, http.StatusNotFound, spec.ErrorCodeNotFound, &message)
+}
+
+// conflict writes an error response and sets the header with the conflict status code.
+func conflict(w http.ResponseWriter, message string) {
+	_ = fault(w, http.StatusConflict, spec.ErrorCodeConflict, &message)
 }
 
 // internalServerError sets the header with the internal server error status code.

--- a/server/internal/transport/http/fault.go
+++ b/server/internal/transport/http/fault.go
@@ -10,7 +10,7 @@ import (
 // Common fault messages.
 const (
 	errRequestBodyInvalid   = "invalid request body"
-	errFieldInvalid         = "invalid field"
+	errFieldValueInvalid    = "invalid field value"
 	errCredentialsIncorrect = "incorrect credentials"
 )
 

--- a/server/internal/transport/http/handler.go
+++ b/server/internal/transport/http/handler.go
@@ -48,9 +48,10 @@ type AuthorizationService interface {
 
 // Service defines the service interface.
 type Service interface {
-	SignInUser(ctx context.Context, username string, password string) (string, error)
+	CreateUser(ctx context.Context, editableUser domain.EditableUserWithPassword) (domain.User, error)
+	SignInUser(ctx context.Context, username domain.Username, password string) (string, error)
 
-	SignInEmployee(ctx context.Context, username string, password string) (string, error)
+	SignInEmployee(ctx context.Context, username domain.Username, password string) (string, error)
 	GetEmployeeByID(ctx context.Context, id uuid.UUID) (domain.Employee, error)
 }
 
@@ -112,11 +113,11 @@ func New(authzService AuthorizationService, service Service) *handler {
 		BaseRouter:  router,
 		Middlewares: []spec.MiddlewareFunc{authzMiddleware},
 		ErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
-			var invalidParamFormatError *spec.InvalidParamFormatError
+			var specInvalidParamFormatError *spec.InvalidParamFormatError
 
 			switch {
-			case errors.As(err, &invalidParamFormatError):
-				badRequest(w, fmt.Sprintf("%s: %s", errParamInvalidFormat, invalidParamFormatError.ParamName))
+			case errors.As(err, &specInvalidParamFormatError):
+				badRequest(w, fmt.Sprintf("%s: %s", errParamInvalidFormat, specInvalidParamFormatError.ParamName))
 			default:
 				badRequest(w, err.Error())
 			}

--- a/server/internal/transport/http/mapper.go
+++ b/server/internal/transport/http/mapper.go
@@ -9,6 +9,13 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/domain"
 )
 
+// dateFromTime returns a standardized date based on the time model.
+func dateFromTime(time time.Time) oapitypes.Date {
+	return oapitypes.Date{
+		Time: time,
+	}
+}
+
 // jwtFromJWTToken returns a standardized JWT based on the JWT token.
 func jwtFromJWTToken(token string) spec.JWT {
 	return spec.JWT{
@@ -16,16 +23,36 @@ func jwtFromJWTToken(token string) spec.JWT {
 	}
 }
 
+// userPostToDomainEditableUserWithPassword returns a domain editable user with password based on the standardized user
+// post.
+func userPostToDomainEditableUserWithPassword(userPost spec.UserPost) domain.EditableUserWithPassword {
+	return domain.EditableUserWithPassword{
+		EditableUser: domain.EditableUser{
+			Username:  domain.Username(userPost.Username),
+			FirstName: domain.Name(userPost.FirstName),
+			LastName:  domain.Name(userPost.LastName),
+		},
+		Password: domain.Password(userPost.Password),
+	}
+}
+
+// userFromDomainUser returns a standardized user based on the domain model.
+func userFromDomainUser(user domain.User) spec.User {
+	return spec.User{
+		Id:           user.ID,
+		Username:     string(user.Username),
+		FirstName:    string(user.FirstName),
+		LastName:     string(user.LastName),
+		CreatedTime:  user.CreatedTime,
+		ModifiedTime: user.ModifiedTime,
+	}
+}
+
 // employeeFromDomain returns a standardized employee based on the domain model.
 func employeeFromDomain(employee domain.Employee) spec.Employee {
 	return spec.Employee{
 		Id:          employee.ID,
-		Name:        employee.FirstName,
+		Name:        string(employee.FirstName),
 		DateOfBirth: dateFromTime(employee.DateOfBirth),
 	}
-}
-
-// dateFromTime returns a standardized date based on the time model.
-func dateFromTime(time time.Time) oapitypes.Date {
-	return oapitypes.Date{Time: time}
 }

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -36,11 +36,11 @@ func (h *handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 	domainEditableUser := userPostToDomainEditableUserWithPassword(userPost)
 	domainUser, err := h.service.CreateUser(ctx, domainEditableUser)
 	if err != nil {
-		var domainErrFieldInvalid *domain.ErrFieldInvalid
+		var domainErrFieldValueInvalid *domain.ErrFieldValueInvalid
 
 		switch {
-		case errors.As(err, &domainErrFieldInvalid):
-			badRequest(w, fmt.Sprintf("%s: %s", errFieldInvalid, domainErrFieldInvalid.FieldName))
+		case errors.As(err, &domainErrFieldValueInvalid):
+			badRequest(w, fmt.Sprintf("%s: %s", errFieldValueInvalid, domainErrFieldValueInvalid.FieldName))
 		case errors.Is(err, domain.ErrUserAlreadyExists):
 			conflict(w, errUserAlreadyExists)
 		default:

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -11,6 +11,41 @@ import (
 	"github.com/goncalo-marques/ecomap/server/internal/logging"
 )
 
+// CreateUser handles the http request to create a user.
+func (h *handler) CreateUser(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement this.
+}
+
+// ListUsers handles the http request to list users.
+func (h *handler) ListUsers(w http.ResponseWriter, r *http.Request, params spec.ListUsersParams) {
+	// TODO: Implement this.
+}
+
+// GetUserByID handles the http request to get a user by ID.
+func (h *handler) GetUserByID(w http.ResponseWriter, r *http.Request, userID spec.UserIdPathParam) {
+	// TODO: Implement this.
+}
+
+// PatchUserByID handles the http request to modify a user by ID.
+func (h *handler) PatchUserByID(w http.ResponseWriter, r *http.Request, userID spec.UserIdPathParam) {
+	// TODO: Implement this.
+}
+
+// DeleteUserByID handles the http request to delete a user by ID.
+func (h *handler) DeleteUserByID(w http.ResponseWriter, r *http.Request, userID spec.UserIdPathParam) {
+	// TODO: Implement this.
+}
+
+// UpdateUserPassword handles the http request to update a user password.
+func (h *handler) UpdateUserPassword(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement this.
+}
+
+// ResetUserPassword handles the http request to reset a user password.
+func (h *handler) ResetUserPassword(w http.ResponseWriter, r *http.Request) {
+	// TODO: Implement this.
+}
+
 // SignInUser handles the http request to sign in a user.
 func (h *handler) SignInUser(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()


### PR DESCRIPTION
Refs: closes #56 

## Summary

Handle the HTTP request to create a new user.

## Changes

- Add `pgconn` word to ignore in cspell
- Add missing conflict error code in the swagger spec
- Add user domain structures
- Add user domain errors
- Add http method to create a user
- Add service method to create a user
- Add store method to create a user
- Update password methods to receive and return bytes instead of string
- Update the password validation to also check for a maximum length
- Update the password validation to also check for a minimum number of regular chars
