### PR TITLE
feat: add endpoint to patch a user

### DIFF
--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -19,13 +19,10 @@ const (
 	fieldFirstName = "firstName"
 	fieldLastName  = "lastName"
 
-	filterLimit     = "limit"
-	filterOffset    = "offset"
-	filterSort      = "sort"
-	filterOrder     = "order"
-	filterUsername  = "username"
-	filterFirstName = "firstName"
-	filterLastName  = "lastName"
+	filterLimit  = "limit"
+	filterOffset = "offset"
+	filterSort   = "sort"
+	filterOrder  = "order"
 
 	descriptionInvalidFieldValue       = "service: invalid field value"
 	descriptionInvalidFilterValue      = "service: invalid filter value"

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -47,6 +47,7 @@ type Store interface {
 	GetUserByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.User, error)
 	GetUserByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.User, error)
 	GetUserSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error)
+	PatchUser(ctx context.Context, tx pgx.Tx, id uuid.UUID, editableUser domain.EditableUserPatch) (domain.User, error)
 
 	GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error)
 	GetEmployeeByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.Employee, error)

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -90,15 +90,6 @@ func (s *service) ListUsers(ctx context.Context, filter domain.UsersFilter) (dom
 	if !filter.Order.Valid() {
 		return domain.PaginatedResponse[domain.User]{}, logInfoAndWrapError(ctx, &domain.ErrFilterValueInvalid{FilterName: filterOrder}, descriptionInvalidFilterValue, logAttrs...)
 	}
-	if filter.Username != nil && !filter.Username.Valid() {
-		return domain.PaginatedResponse[domain.User]{}, logInfoAndWrapError(ctx, &domain.ErrFilterValueInvalid{FilterName: filterUsername}, descriptionInvalidFilterValue, logAttrs...)
-	}
-	if filter.FirstName != nil && !filter.FirstName.Valid() {
-		return domain.PaginatedResponse[domain.User]{}, logInfoAndWrapError(ctx, &domain.ErrFilterValueInvalid{FilterName: filterFirstName}, descriptionInvalidFilterValue, logAttrs...)
-	}
-	if filter.LastName != nil && !filter.LastName.Valid() {
-		return domain.PaginatedResponse[domain.User]{}, logInfoAndWrapError(ctx, &domain.ErrFilterValueInvalid{FilterName: filterLastName}, descriptionInvalidFilterValue, logAttrs...)
-	}
 
 	var paginatedUsers domain.PaginatedResponse[domain.User]
 	var err error

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -19,6 +19,7 @@ const (
 	descriptionFailedGetUserByID       = "service: failed to get user by id"
 	descriptionFailedGetUserByUsername = "service: failed to get user by username"
 	descriptionFailedGetUserSignIn     = "service: failed to get user sign-in"
+	descriptionFailedPatchUser         = "service: failed to patch user"
 )
 
 // CreateUser creates a new user with the specified data.
@@ -180,4 +181,54 @@ func (s *service) SignInUser(ctx context.Context, username domain.Username, pass
 	}
 
 	return token, nil
+}
+
+// PatchUser modifies the user with the specified identifier. Only the specified fields in the request body are updated.
+func (s *service) PatchUser(ctx context.Context, id uuid.UUID, editableUser domain.EditableUserPatch) (domain.User, error) {
+	logAttrs := []any{
+		slog.String(logging.ServiceMethod, "PatchUser"),
+		slog.String(logging.UserID, id.String()),
+	}
+
+	if editableUser.Username != nil {
+		username := domain.Username(replaceSpacesWithHyphen(string(*editableUser.Username)))
+		editableUser.Username = &username
+	}
+	if editableUser.FirstName != nil {
+		firstName := domain.Name(replaceSpacesWithHyphen(string(*editableUser.FirstName)))
+		editableUser.FirstName = &firstName
+	}
+	if editableUser.LastName != nil {
+		lastName := domain.Name(replaceSpacesWithHyphen(string(*editableUser.LastName)))
+		editableUser.LastName = &lastName
+	}
+
+	if editableUser.Username != nil && !editableUser.Username.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldUsername}, descriptionInvalidFieldValue, logAttrs...)
+	}
+	if editableUser.FirstName != nil && !editableUser.FirstName.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldFirstName}, descriptionInvalidFieldValue, logAttrs...)
+	}
+	if editableUser.LastName != nil && !editableUser.LastName.Valid() {
+		return domain.User{}, logInfoAndWrapError(ctx, &domain.ErrFieldValueInvalid{FieldName: fieldLastName}, descriptionInvalidFieldValue, logAttrs...)
+	}
+
+	var user domain.User
+	var err error
+
+	err = s.readWriteTx(ctx, func(tx pgx.Tx) error {
+		user, err = s.store.PatchUser(ctx, tx, id, editableUser)
+		return err
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrUserNotFound),
+			errors.Is(err, domain.ErrUserAlreadyExists):
+			return domain.User{}, logInfoAndWrapError(ctx, err, descriptionFailedPatchUser, logAttrs...)
+		default:
+			return domain.User{}, logAndWrapError(ctx, err, descriptionFailedPatchUser, logAttrs...)
+		}
+	}
+
+	return user, nil
 }

--- a/server/internal/transport/http/handler.go
+++ b/server/internal/transport/http/handler.go
@@ -51,6 +51,7 @@ type Service interface {
 	CreateUser(ctx context.Context, editableUser domain.EditableUserWithPassword) (domain.User, error)
 	ListUsers(ctx context.Context, filter domain.UsersFilter) (domain.PaginatedResponse[domain.User], error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (domain.User, error)
+	PatchUser(ctx context.Context, id uuid.UUID, editableUser domain.EditableUserPatch) (domain.User, error)
 	SignInUser(ctx context.Context, username domain.Username, password string) (string, error)
 
 	GetEmployeeByID(ctx context.Context, id uuid.UUID) (domain.Employee, error)

--- a/server/internal/transport/http/mapper.go
+++ b/server/internal/transport/http/mapper.go
@@ -69,6 +69,15 @@ func userPostToDomainEditableUserWithPassword(userPost spec.UserPost) domain.Edi
 	}
 }
 
+// userPatchToDomainEditableUserPatch returns a domain patchable user based on the standardized user patch.
+func userPatchToDomainEditableUserPatch(userPatch spec.UserPatch) domain.EditableUserPatch {
+	return domain.EditableUserPatch{
+		Username:  (*domain.Username)(userPatch.Username),
+		FirstName: (*domain.Name)(userPatch.FirstName),
+		LastName:  (*domain.Name)(userPatch.LastName),
+	}
+}
+
 // userFromDomain returns a standardized user based on the domain model.
 func userFromDomain(user domain.User) spec.User {
 	return spec.User{


### PR DESCRIPTION
Refs: closes #66 

## Summary

Handle the HTTP request to patch a user.

## Changes

- Remove unnecessary filter validations from the list endpoint
- Add http method to patch a user
- Add service method to patch a user
- Add store method to patch a user
