### PR TITLE
feat: add endpoint to update user password

### DIFF
--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -46,7 +46,7 @@ func (s *service) GetEmployeeByID(ctx context.Context, id uuid.UUID) (domain.Emp
 }
 
 // SignInEmployee returns a JSON Web Token for the specified username and password.
-func (s *service) SignInEmployee(ctx context.Context, username domain.Username, password string) (string, error) {
+func (s *service) SignInEmployee(ctx context.Context, username domain.Username, password domain.Password) (string, error) {
 	logAttrs := []any{
 		slog.String(logging.ServiceMethod, "SignInEmployee"),
 		slog.String(logging.EmployeeUsername, string(username)),

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	fieldUsername  = "username"
-	fieldPassword  = "password"
-	fieldFirstName = "firstName"
-	fieldLastName  = "lastName"
+	fieldUsername    = "username"
+	fieldPassword    = "password"
+	fieldNewPassword = "newPassword"
+	fieldFirstName   = "firstName"
+	fieldLastName    = "lastName"
 
 	filterLimit  = "limit"
 	filterOffset = "offset"
@@ -48,6 +49,7 @@ type Store interface {
 	GetUserByUsername(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.User, error)
 	GetUserSignIn(ctx context.Context, tx pgx.Tx, username domain.Username) (domain.SignIn, error)
 	PatchUser(ctx context.Context, tx pgx.Tx, id uuid.UUID, editableUser domain.EditableUserPatch) (domain.User, error)
+	UpdateUserPassword(ctx context.Context, tx pgx.Tx, username domain.Username, password domain.Password) error
 	DeleteUserByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.User, error)
 
 	GetEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) (domain.Employee, error)

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -210,7 +210,7 @@ func (s *service) DeleteUserByID(ctx context.Context, id uuid.UUID) (domain.User
 }
 
 // SignInUser returns a JSON Web Token for the specified username and password.
-func (s *service) SignInUser(ctx context.Context, username domain.Username, password string) (string, error) {
+func (s *service) SignInUser(ctx context.Context, username domain.Username, password domain.Password) (string, error) {
 	logAttrs := []any{
 		slog.String(logging.ServiceMethod, "SignInUser"),
 		slog.String(logging.UserUsername, string(username)),

--- a/server/internal/store/store.go
+++ b/server/internal/store/store.go
@@ -19,6 +19,7 @@ import (
 // Common failure descriptions.
 const (
 	descriptionFailedQuery    = "store: failed to query"
+	descriptionFailedExec     = "store: failed to exec"
 	descriptionFailedScanRow  = "store: failed to scan row"
 	descriptionFailedScanRows = "store: failed to scan rows"
 )

--- a/server/internal/transport/http/employee.go
+++ b/server/internal/transport/http/employee.go
@@ -59,7 +59,7 @@ func (h *handler) SignInEmployee(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.service.SignInEmployee(ctx, domain.Username(signIn.Username), signIn.Password)
+	token, err := h.service.SignInEmployee(ctx, domain.Username(signIn.Username), domain.Password(signIn.Password))
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrCredentialsIncorrect):

--- a/server/internal/transport/http/handler.go
+++ b/server/internal/transport/http/handler.go
@@ -52,11 +52,12 @@ type Service interface {
 	ListUsers(ctx context.Context, filter domain.UsersFilter) (domain.PaginatedResponse[domain.User], error)
 	GetUserByID(ctx context.Context, id uuid.UUID) (domain.User, error)
 	PatchUser(ctx context.Context, id uuid.UUID, editableUser domain.EditableUserPatch) (domain.User, error)
+	UpdateUserPassword(ctx context.Context, username domain.Username, oldPassword, newPassword domain.Password) error
 	DeleteUserByID(ctx context.Context, id uuid.UUID) (domain.User, error)
-	SignInUser(ctx context.Context, username domain.Username, password string) (string, error)
+	SignInUser(ctx context.Context, username domain.Username, password domain.Password) (string, error)
 
 	GetEmployeeByID(ctx context.Context, id uuid.UUID) (domain.Employee, error)
-	SignInEmployee(ctx context.Context, username domain.Username, password string) (string, error)
+	SignInEmployee(ctx context.Context, username domain.Username, password domain.Password) (string, error)
 }
 
 // handler defines the http handler structure.

--- a/server/internal/transport/http/mapper.go
+++ b/server/internal/transport/http/mapper.go
@@ -56,6 +56,16 @@ func orderToDomain(order *spec.OrderQueryParam) domain.Order {
 	return domain.Order(*order)
 }
 
+// paginatedRequestToDomain returns a domain paginated request based on the standardized query parameter models.
+func paginatedRequestToDomain[T any](limit *spec.LimitQueryParam, offset *spec.OffsetQueryParam, order *spec.OrderQueryParam, sort domain.Sort[T]) domain.PaginatedRequest[T] {
+	return domain.PaginatedRequest[T]{
+		Limit:  limitToDomain(limit),
+		Offset: offsetToDomain(offset),
+		Sort:   sort,
+		Order:  orderToDomain(order),
+	}
+}
+
 // userPostToDomainEditableUserWithPassword returns a domain editable user with password based on the standardized user
 // post.
 func userPostToDomainEditableUserWithPassword(userPost spec.UserPost) domain.EditableUserWithPassword {
@@ -75,6 +85,26 @@ func userPatchToDomainEditableUserPatch(userPatch spec.UserPatch) domain.Editabl
 		Username:  (*domain.Username)(userPatch.Username),
 		FirstName: (*domain.Name)(userPatch.FirstName),
 		LastName:  (*domain.Name)(userPatch.LastName),
+	}
+}
+
+// listUsersParamsToDomainUsersFilter returns a domain users filter based on the standardized list users parameters.
+func listUsersParamsToDomainUsersFilter(params spec.ListUsersParams) domain.UsersFilter {
+	var domainSort domain.Sort[domain.UserSort]
+	if params.Sort != nil {
+		domainSort = domain.UserSort(*params.Sort)
+	}
+
+	return domain.UsersFilter{
+		PaginatedRequest: paginatedRequestToDomain(
+			params.Limit,
+			params.Offset,
+			(*spec.OrderQueryParam)(params.Order),
+			domainSort,
+		),
+		Username:  (*domain.Username)(params.Username),
+		FirstName: (*domain.Name)(params.FirstName),
+		LastName:  (*domain.Name)(params.LastName),
 	}
 }
 
@@ -98,6 +128,14 @@ func usersFromDomain(users []domain.User) []spec.User {
 	}
 
 	return specUsers
+}
+
+// usersPaginatedFromDomain returns a standardized users paginated response based on the domain model.
+func usersPaginatedFromDomain(paginatedResponse domain.PaginatedResponse[domain.User]) spec.UsersPaginated {
+	return spec.UsersPaginated{
+		Total: paginatedResponse.Total,
+		Users: usersFromDomain(paginatedResponse.Results),
+	}
 }
 
 // employeeFromDomain returns a standardized employee based on the domain model.

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -66,23 +66,7 @@ func (h *handler) CreateUser(w http.ResponseWriter, r *http.Request) {
 func (h *handler) ListUsers(w http.ResponseWriter, r *http.Request, params spec.ListUsersParams) {
 	ctx := r.Context()
 
-	var domainSort domain.Sort[domain.UserSort]
-	if params.Sort != nil {
-		domainSort = domain.UserSort(*params.Sort)
-	}
-
-	domainUsersFilter := domain.UsersFilter{
-		PaginatedRequest: domain.PaginatedRequest[domain.UserSort]{
-			Limit:  limitToDomain(params.Limit),
-			Offset: offsetToDomain(params.Offset),
-			Sort:   domainSort,
-			Order:  orderToDomain((*spec.OrderQueryParam)(params.Order)),
-		},
-		Username:  (*domain.Username)(params.Username),
-		FirstName: (*domain.Name)(params.FirstName),
-		LastName:  (*domain.Name)(params.LastName),
-	}
-
+	domainUsersFilter := listUsersParamsToDomainUsersFilter(params)
 	domainPaginatedUsers, err := h.service.ListUsers(ctx, domainUsersFilter)
 	if err != nil {
 		var domainErrFilterValueInvalid *domain.ErrFilterValueInvalid
@@ -97,13 +81,8 @@ func (h *handler) ListUsers(w http.ResponseWriter, r *http.Request, params spec.
 		return
 	}
 
-	users := usersFromDomain(domainPaginatedUsers.Results)
-	specUsersPaginated := spec.UsersPaginated{
-		Total: domainPaginatedUsers.Total,
-		Users: users,
-	}
-
-	responseBody, err := json.Marshal(specUsersPaginated)
+	usersPaginated := usersPaginatedFromDomain(domainPaginatedUsers)
+	responseBody, err := json.Marshal(usersPaginated)
 	if err != nil {
 		logging.Logger.ErrorContext(ctx, descriptionFailedToMarshalResponseBody, logging.Error(err))
 		internalServerError(w)

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -220,7 +220,7 @@ func (h *handler) SignInUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := h.service.SignInUser(ctx, domain.Username(signIn.Username), signIn.Password)
+	token, err := h.service.SignInUser(ctx, domain.Username(signIn.Username), domain.Password(signIn.Password))
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrCredentialsIncorrect):


### PR DESCRIPTION
Refs: closes #70 

## Summary

Handle the HTTP request to update a user password.

## Changes

- Update passwords to use domain model instead of string
- Add missing list http mapper functions
- Add http method to update a user password
- Add service method to update a user password
- Add store method to update a user password