### PR TITLE
fix: add missing feature type

### DIFF
--- a/server/internal/transport/http/mapper.go
+++ b/server/internal/transport/http/mapper.go
@@ -115,6 +115,7 @@ func geoJSONFeatureCollectionLineStringFromDomain(geoJSON domain.GeoJSON) (spec.
 		}
 
 		specGeoJSONFeatureLineString[i] = spec.GeoJSONFeatureLineString{
+			Type: spec.GeoJSONFeatureLineStringTypeFeature,
 			Geometry: spec.GeoJSONGeometryLineString{
 				Type:        spec.LineString,
 				Coordinates: specCoordinates,


### PR DESCRIPTION
## Summary

Add missing GeoJSON feature type in the HTTP Line String mapper.
