### PR TITLE
feat: delete associations on cascade

### DIFF
--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -676,7 +676,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         409:
-          description: Employee is associated with a report.
+          description: Employee is associated with a route.
           content:
             application/json:
               schema:
@@ -967,7 +967,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         409:
-          description: Container is associated with a report or bookmark.
+          description: Container is associated with a bookmark or route.
           content:
             application/json:
               schema:

--- a/server/api/swagger/ecomap.yml
+++ b/server/api/swagger/ecomap.yml
@@ -231,12 +231,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        409:
-          description: User is associated with a report or a bookmark.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
         500:
           $ref: "#/components/responses/InternalServerError"
   /users/password:
@@ -682,7 +676,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         409:
-          description: Employee is associated with a report or a route.
+          description: Employee is associated with a report.
           content:
             application/json:
               schema:
@@ -973,7 +967,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         409:
-          description: Container is associated with a report, bookmark, or route.
+          description: Container is associated with a report or bookmark.
           content:
             application/json:
               schema:
@@ -1366,7 +1360,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
         409:
-          description: Warehouse is associated with a truck or a route.
+          description: Warehouse is associated with a route.
           content:
             application/json:
               schema:
@@ -1758,12 +1752,6 @@ paths:
           $ref: "#/components/responses/Forbidden"
         404:
           description: Route not found.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
-        409:
-          description: Route is associated with a container or employee.
           content:
             application/json:
               schema:

--- a/server/database/migrations/000001_initial_database.up.sql
+++ b/server/database/migrations/000001_initial_database.up.sql
@@ -103,15 +103,15 @@ CREATE TABLE containers_reports (
     issue_type      containers_reports_issue_type   NOT NULL,
     description     varchar(500),
     attachment      bytea,
-    issuer_id       uuid                            NOT NULL,
+    issuer_id       uuid,
     resolver_id     uuid,
     resolved        boolean                         NOT NULL    DEFAULT FALSE,
     created_at      timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     modified_at     timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT containers_reports_pkey              PRIMARY KEY (id),
-    CONSTRAINT containers_reports_container_id_fkey FOREIGN KEY (container_id)  REFERENCES containers (id),
-    CONSTRAINT containers_reports_issuer_id_fkey    FOREIGN KEY (issuer_id)     REFERENCES users (id),
-    CONSTRAINT containers_reports_resolver_id_fkey  FOREIGN KEY (resolver_id)   REFERENCES employees (id)
+    CONSTRAINT containers_reports_container_id_fkey FOREIGN KEY (container_id)  REFERENCES containers (id)  ON DELETE CASCADE,
+    CONSTRAINT containers_reports_issuer_id_fkey    FOREIGN KEY (issuer_id)     REFERENCES users (id)       ON DELETE SET NULL,
+    CONSTRAINT containers_reports_resolver_id_fkey  FOREIGN KEY (resolver_id)   REFERENCES employees (id)   ON DELETE SET NULL
 );
 
 CREATE TRIGGER containers_reports_update_modified_at
@@ -127,7 +127,7 @@ CREATE TABLE users_container_bookmarks (
     container_id    uuid        NOT NULL,
     created_at      timestamp   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT users_container_bookmarks_pkey               PRIMARY KEY (user_id, container_id),
-    CONSTRAINT users_container_bookmarks_user_id_fkey       FOREIGN KEY (user_id)               REFERENCES users (id),
+    CONSTRAINT users_container_bookmarks_user_id_fkey       FOREIGN KEY (user_id)               REFERENCES users (id)       ON DELETE CASCADE,
     CONSTRAINT users_container_bookmarks_container_id_fkey  FOREIGN KEY (container_id)          REFERENCES containers (id)
 );
 
@@ -172,7 +172,7 @@ CREATE TABLE warehouses_trucks (
     truck_id        uuid        NOT NULL,
     created_at      timestamp   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT warehouses_trucks_pkey               PRIMARY KEY (warehouse_id, truck_id),
-    CONSTRAINT warehouses_trucks_warehouse_id_fkey  FOREIGN KEY (warehouse_id)              REFERENCES warehouses (id),
+    CONSTRAINT warehouses_trucks_warehouse_id_fkey  FOREIGN KEY (warehouse_id)              REFERENCES warehouses (id)  ON DELETE CASCADE,
     CONSTRAINT warehouses_trucks_truck_id_fkey      FOREIGN KEY (truck_id)                  REFERENCES trucks (id),
     CONSTRAINT warehouses_trucks_truck_id_key       UNIQUE (truck_id)
 );
@@ -203,7 +203,7 @@ CREATE TABLE routes_containers (
     container_id    uuid        NOT NULL,
     created_at      timestamp   NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT routes_containers_pkey               PRIMARY KEY (route_id, container_id),
-    CONSTRAINT routes_containers_route_id_fkey      FOREIGN KEY (route_id)                  REFERENCES routes (id),
+    CONSTRAINT routes_containers_route_id_fkey      FOREIGN KEY (route_id)                  REFERENCES routes (id)      ON DELETE CASCADE,
     CONSTRAINT routes_containers_container_id_fkey  FOREIGN KEY (container_id)              REFERENCES containers (id)
 );
 
@@ -216,6 +216,6 @@ CREATE TABLE routes_employees (
     employee_role   routes_employees_employee_role  NOT NULL,
     created_at      timestamp                       NOT NULL    DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT routes_employees_pkey                PRIMARY KEY (route_id, employee_id),
-    CONSTRAINT routes_employees_route_id_fkey       FOREIGN KEY (route_id)              REFERENCES routes (id),
+    CONSTRAINT routes_employees_route_id_fkey       FOREIGN KEY (route_id)              REFERENCES routes (id)      ON DELETE CASCADE,
     CONSTRAINT routes_employees_employee_id_fkey    FOREIGN KEY (employee_id)           REFERENCES employees (id)
 );

--- a/server/internal/domain/container.go
+++ b/server/internal/domain/container.go
@@ -10,7 +10,6 @@ import (
 // Container errors.
 var (
 	ErrContainerNotFound                            = errors.New("container not found")                     // Returned when a container is not found.
-	ErrContainerAssociatedWithContainerReport       = errors.New("container associated with user report")   // Returned when a container is associated with a user report.
 	ErrContainerAssociatedWithUserContainerBookmark = errors.New("container associated with user bookmark") // Returned when a container is associated with a user bookmark.
 	ErrContainerAssociatedWithRouteContainer        = errors.New("container associated with route")         // Returned when a container is associated with a route.
 )

--- a/server/internal/domain/employee.go
+++ b/server/internal/domain/employee.go
@@ -9,10 +9,9 @@ import (
 
 // Employee errors.
 var (
-	ErrEmployeeAlreadyExists                           = errors.New("username already exists")                               // Returned when an employee already exists with the same username.
-	ErrEmployeeNotFound                                = errors.New("employee not found")                                    // Returned when an employee is not found.
-	ErrEmployeeAssociatedWithContainerReportAsResolver = errors.New("employee associated with container report as resolver") // Returned when an employee is associated with a container report as a resolver.
-	ErrEmployeeAssociatedWithRouteEmployee             = errors.New("employee associated with route")                        // Returned when an employee is associated with a route.
+	ErrEmployeeAlreadyExists               = errors.New("username already exists")        // Returned when an employee already exists with the same username.
+	ErrEmployeeNotFound                    = errors.New("employee not found")             // Returned when an employee is not found.
+	ErrEmployeeAssociatedWithRouteEmployee = errors.New("employee associated with route") // Returned when an employee is associated with a route.
 )
 
 // EmployeeRole defines the role of the employee.

--- a/server/internal/domain/route.go
+++ b/server/internal/domain/route.go
@@ -14,13 +14,11 @@ const (
 
 // Route errors.
 var (
-	ErrRouteNotFound                     = errors.New("route not found")                                 // Returned when a route is not found.
-	ErrRouteDepartureWarehouseNotFound   = errors.New("route departure warehouse not found")             // Returned when a route departure warehouse is not found.
-	ErrRouteArrivalWarehouseNotFound     = errors.New("route arrival warehouse not found")               // Returned when a route arrival warehouse is not found.
-	ErrRouteTruckPersonCapacityMinLimit  = errors.New("route truck person capacity below minimum limit") // Returned when a route truck person capacity is below the minimum limit.
-	ErrRouteTruckPersonCapacityMaxLimit  = errors.New("route truck person capacity above maximum limit") // Returned when a route truck person capacity is above the maximum limit.
-	ErrRouteAssociatedWithRouteContainer = errors.New("route associated with container")                 // Returned when a route is associated with a container.
-	ErrRouteAssociatedWithRouteEmployee  = errors.New("route associated with employee")                  // Returned when a route is associated with an employee.
+	ErrRouteNotFound                    = errors.New("route not found")                                 // Returned when a route is not found.
+	ErrRouteDepartureWarehouseNotFound  = errors.New("route departure warehouse not found")             // Returned when a route departure warehouse is not found.
+	ErrRouteArrivalWarehouseNotFound    = errors.New("route arrival warehouse not found")               // Returned when a route arrival warehouse is not found.
+	ErrRouteTruckPersonCapacityMinLimit = errors.New("route truck person capacity below minimum limit") // Returned when a route truck person capacity is below the minimum limit.
+	ErrRouteTruckPersonCapacityMaxLimit = errors.New("route truck person capacity above maximum limit") // Returned when a route truck person capacity is above the maximum limit.
 )
 
 // RouteName defines the route name type.

--- a/server/internal/domain/user.go
+++ b/server/internal/domain/user.go
@@ -9,10 +9,8 @@ import (
 
 // User errors.
 var (
-	ErrUserAlreadyExists                         = errors.New("username already exists")                         // Returned when a user already exists with the same username.
-	ErrUserNotFound                              = errors.New("user not found")                                  // Returned when a user is not found.
-	ErrUserAssociatedWithUserContainerBookmark   = errors.New("user associated with container bookmark")         // Returned when a user is associated with a container bookmark.
-	ErrUserAssociatedWithContainerReportAsIssuer = errors.New("user associated with container report as issuer") // Returned when a user is associated with a container report as an issuer.
+	ErrUserAlreadyExists = errors.New("username already exists") // Returned when a user already exists with the same username.
+	ErrUserNotFound      = errors.New("user not found")          // Returned when a user is not found.
 )
 
 // EditableUser defines the editable user structure.

--- a/server/internal/domain/warehouse.go
+++ b/server/internal/domain/warehouse.go
@@ -16,7 +16,6 @@ const (
 var (
 	ErrWarehouseNotFound                     = errors.New("warehouse not found")                          // Returned when a warehouse is not found.
 	ErrWarehouseTruckCapacityMinLimit        = errors.New("warehouse truck capacity below minimum limit") // Returned when a warehouse truck capacity is below the minimum limit.
-	ErrWarehouseAssociatedWithWarehouseTruck = errors.New("warehouse associated with truck")              // Returned when a warehouse is associated with a truck.
 	ErrWarehouseAssociatedWithRouteDeparture = errors.New("warehouse associated with route as departure") // Returned when a warehouse is associated with a route as a departure.
 	ErrWarehouseAssociatedWithRouteArrival   = errors.New("warehouse associated with route as arrival")   // Returned when a warehouse is associated with a route as an arrival.
 )

--- a/server/internal/service/container.go
+++ b/server/internal/service/container.go
@@ -236,7 +236,6 @@ func (s *service) DeleteContainerByID(ctx context.Context, id uuid.UUID) (domain
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrContainerNotFound),
-			errors.Is(err, domain.ErrContainerAssociatedWithContainerReport),
 			errors.Is(err, domain.ErrContainerAssociatedWithUserContainerBookmark),
 			errors.Is(err, domain.ErrContainerAssociatedWithRouteContainer):
 			return domain.Container{}, logInfoAndWrapError(ctx, err, descriptionFailedDeleteContainerByID, logAttrs...)

--- a/server/internal/service/employee.go
+++ b/server/internal/service/employee.go
@@ -402,7 +402,6 @@ func (s *service) DeleteEmployeeByID(ctx context.Context, id uuid.UUID) (domain.
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrEmployeeNotFound),
-			errors.Is(err, domain.ErrEmployeeAssociatedWithContainerReportAsResolver),
 			errors.Is(err, domain.ErrEmployeeAssociatedWithRouteEmployee):
 			return domain.Employee{}, logInfoAndWrapError(ctx, err, descriptionFailedDeleteEmployeeByID, logAttrs...)
 		default:

--- a/server/internal/service/route.go
+++ b/server/internal/service/route.go
@@ -207,9 +207,7 @@ func (s *service) DeleteRouteByID(ctx context.Context, id uuid.UUID) (domain.Rou
 	})
 	if err != nil {
 		switch {
-		case errors.Is(err, domain.ErrRouteNotFound),
-			errors.Is(err, domain.ErrRouteAssociatedWithRouteContainer),
-			errors.Is(err, domain.ErrRouteAssociatedWithRouteEmployee):
+		case errors.Is(err, domain.ErrRouteNotFound):
 			return domain.Route{}, logInfoAndWrapError(ctx, err, descriptionFailedDeleteRouteByID, logAttrs...)
 		default:
 			return domain.Route{}, logAndWrapError(ctx, err, descriptionFailedDeleteRouteByID, logAttrs...)

--- a/server/internal/service/user.go
+++ b/server/internal/service/user.go
@@ -327,9 +327,7 @@ func (s *service) DeleteUserByID(ctx context.Context, id uuid.UUID) (domain.User
 	})
 	if err != nil {
 		switch {
-		case errors.Is(err, domain.ErrUserNotFound),
-			errors.Is(err, domain.ErrUserAssociatedWithUserContainerBookmark),
-			errors.Is(err, domain.ErrUserAssociatedWithContainerReportAsIssuer):
+		case errors.Is(err, domain.ErrUserNotFound):
 			return domain.User{}, logInfoAndWrapError(ctx, err, descriptionFailedDeleteUserByID, logAttrs...)
 		default:
 			return domain.User{}, logAndWrapError(ctx, err, descriptionFailedDeleteUserByID, logAttrs...)

--- a/server/internal/service/warehouse.go
+++ b/server/internal/service/warehouse.go
@@ -247,7 +247,6 @@ func (s *service) DeleteWarehouseByID(ctx context.Context, id uuid.UUID) (domain
 	if err != nil {
 		switch {
 		case errors.Is(err, domain.ErrWarehouseNotFound),
-			errors.Is(err, domain.ErrWarehouseAssociatedWithWarehouseTruck),
 			errors.Is(err, domain.ErrWarehouseAssociatedWithRouteDeparture),
 			errors.Is(err, domain.ErrWarehouseAssociatedWithRouteArrival):
 			return domain.Warehouse{}, logInfoAndWrapError(ctx, err, descriptionFailedDeleteWarehouseByID, logAttrs...)

--- a/server/internal/store/container.go
+++ b/server/internal/store/container.go
@@ -201,8 +201,6 @@ func (s *store) DeleteContainerByID(ctx context.Context, tx pgx.Tx, id uuid.UUID
 	)
 	if err != nil {
 		switch constraintNameFromError(err) {
-		case constraintContainersReportsContainerIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrContainerAssociatedWithContainerReport)
 		case constraintUsersContainerBookmarksContainerIDFkey:
 			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrContainerAssociatedWithUserContainerBookmark)
 		case constraintRoutesContainersContainerIDFkey:

--- a/server/internal/store/container_report.go
+++ b/server/internal/store/container_report.go
@@ -1,7 +1,0 @@
-package store
-
-const (
-	constraintContainersReportsContainerIDFkey = "containers_reports_container_id_fkey"
-	constraintContainersReportsIssuerIDFkey    = "containers_reports_issuer_id_fkey"
-	constraintContainersReportsResolverIDFkey  = "containers_reports_resolver_id_fkey"
-)

--- a/server/internal/store/employee.go
+++ b/server/internal/store/employee.go
@@ -338,8 +338,6 @@ func (s *store) DeleteEmployeeByID(ctx context.Context, tx pgx.Tx, id uuid.UUID)
 	)
 	if err != nil {
 		switch constraintNameFromError(err) {
-		case constraintContainersReportsResolverIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrEmployeeAssociatedWithContainerReportAsResolver)
 		case constraintRoutesEmployeesEmployeeIDFkey:
 			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrEmployeeAssociatedWithRouteEmployee)
 		}

--- a/server/internal/store/route.go
+++ b/server/internal/store/route.go
@@ -224,13 +224,6 @@ func (s *store) DeleteRouteByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) er
 		id,
 	)
 	if err != nil {
-		switch constraintNameFromError(err) {
-		case constraintRoutesContainersRouteIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrRouteAssociatedWithRouteContainer)
-		case constraintRoutesEmployeesRouteIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrRouteAssociatedWithRouteEmployee)
-		}
-
 		return fmt.Errorf("%s: %w", descriptionFailedExec, err)
 	}
 

--- a/server/internal/store/user.go
+++ b/server/internal/store/user.go
@@ -249,13 +249,6 @@ func (s *store) DeleteUserByID(ctx context.Context, tx pgx.Tx, id uuid.UUID) err
 		id,
 	)
 	if err != nil {
-		switch constraintNameFromError(err) {
-		case constraintUsersContainerBookmarksUserIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrUserAssociatedWithUserContainerBookmark)
-		case constraintContainersReportsIssuerIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrUserAssociatedWithContainerReportAsIssuer)
-		}
-
 		return fmt.Errorf("%s: %w", descriptionFailedExec, err)
 	}
 

--- a/server/internal/store/warehouse.go
+++ b/server/internal/store/warehouse.go
@@ -190,8 +190,6 @@ func (s *store) DeleteWarehouseByID(ctx context.Context, tx pgx.Tx, id uuid.UUID
 	)
 	if err != nil {
 		switch constraintNameFromError(err) {
-		case constraintWarehousesTrucksWarehouseIDFkey:
-			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrWarehouseAssociatedWithWarehouseTruck)
 		case constraintRoutesDepartureWarehouseIDFkey:
 			return fmt.Errorf("%s: %w", descriptionFailedExec, domain.ErrWarehouseAssociatedWithRouteDeparture)
 		case constraintRoutesArrivalWarehouseIDFkey:

--- a/server/internal/store/warehouse_truck.go
+++ b/server/internal/store/warehouse_truck.go
@@ -11,8 +11,7 @@ import (
 )
 
 const (
-	constraintWarehousesTrucksWarehouseIDFkey = "warehouses_trucks_warehouse_id_fkey"
-	constraintWarehousesTrucksTruckIDFkey     = "warehouses_trucks_truck_id_fkey"
+	constraintWarehousesTrucksTruckIDFkey = "warehouses_trucks_truck_id_fkey"
 )
 
 // ListWarehouseTrucks executes a query to return the trucks associated with the warehouse with the specified identifier.

--- a/server/internal/transport/http/container.go
+++ b/server/internal/transport/http/container.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	errContainerNotFound                            = "container not found"
-	errContainerAssociatedWithContainerReport       = "container associated with user report"
 	errContainerAssociatedWithUserContainerBookmark = "container associated with user bookmark"
 	errContainerAssociatedWithRouteContainer        = "container associated with route"
 )
@@ -223,8 +222,6 @@ func (h *handler) DeleteContainerByID(w http.ResponseWriter, r *http.Request, co
 		switch {
 		case errors.Is(err, domain.ErrContainerNotFound):
 			notFound(w, errContainerNotFound)
-		case errors.Is(err, domain.ErrContainerAssociatedWithContainerReport):
-			conflict(w, errContainerAssociatedWithContainerReport)
 		case errors.Is(err, domain.ErrContainerAssociatedWithUserContainerBookmark):
 			conflict(w, errContainerAssociatedWithUserContainerBookmark)
 		case errors.Is(err, domain.ErrContainerAssociatedWithRouteContainer):

--- a/server/internal/transport/http/employee.go
+++ b/server/internal/transport/http/employee.go
@@ -14,10 +14,9 @@ import (
 )
 
 const (
-	errEmployeeNotFound                                = "employee not found"
-	errEmployeeAlreadyExists                           = "username already exists"
-	errEmployeeAssociatedWithContainerReportAsResolver = "employee associated with container report as resolver"
-	errEmployeeAssociatedWithRouteEmployee             = "employee associated with route"
+	errEmployeeNotFound                    = "employee not found"
+	errEmployeeAlreadyExists               = "username already exists"
+	errEmployeeAssociatedWithRouteEmployee = "employee associated with route"
 )
 
 // CreateEmployee handles the http request to create an employee.
@@ -228,8 +227,6 @@ func (h *handler) DeleteEmployeeByID(w http.ResponseWriter, r *http.Request, emp
 		switch {
 		case errors.Is(err, domain.ErrEmployeeNotFound):
 			notFound(w, errEmployeeNotFound)
-		case errors.Is(err, domain.ErrEmployeeAssociatedWithContainerReportAsResolver):
-			conflict(w, errEmployeeAssociatedWithContainerReportAsResolver)
 		case errors.Is(err, domain.ErrEmployeeAssociatedWithRouteEmployee):
 			conflict(w, errEmployeeAssociatedWithRouteEmployee)
 		default:

--- a/server/internal/transport/http/route.go
+++ b/server/internal/transport/http/route.go
@@ -13,13 +13,11 @@ import (
 )
 
 const (
-	errRouteNotFound                     = "route not found"
-	errRouteDepartureWarehouseNotFound   = "route departure warehouse not found"
-	errRouteArrivalWarehouseNotFound     = "route arrival warehouse not found"
-	errRouteTruckPersonCapacityMinLimit  = "route already has more employees than the new truck has capacity"
-	errRouteTruckPersonCapacityMaxLimit  = "route cannot have more employees than the truck has capacity"
-	errRouteAssociatedWithRouteContainer = "route associated with container"
-	errRouteAssociatedWithRouteEmployee  = "route associated with employee"
+	errRouteNotFound                    = "route not found"
+	errRouteDepartureWarehouseNotFound  = "route departure warehouse not found"
+	errRouteArrivalWarehouseNotFound    = "route arrival warehouse not found"
+	errRouteTruckPersonCapacityMinLimit = "route already has more employees than the new truck has capacity"
+	errRouteTruckPersonCapacityMaxLimit = "route cannot have more employees than the truck has capacity"
 )
 
 // CreateRoute handles the http request to create a route.
@@ -214,10 +212,6 @@ func (h *handler) DeleteRouteByID(w http.ResponseWriter, r *http.Request, routeI
 		switch {
 		case errors.Is(err, domain.ErrRouteNotFound):
 			notFound(w, errRouteNotFound)
-		case errors.Is(err, domain.ErrRouteAssociatedWithRouteContainer):
-			conflict(w, errRouteAssociatedWithRouteContainer)
-		case errors.Is(err, domain.ErrRouteAssociatedWithRouteEmployee):
-			conflict(w, errRouteAssociatedWithRouteEmployee)
 		default:
 			internalServerError(w)
 		}

--- a/server/internal/transport/http/user.go
+++ b/server/internal/transport/http/user.go
@@ -13,10 +13,8 @@ import (
 )
 
 const (
-	errUserNotFound                              = "user not found"
-	errUserAlreadyExists                         = "username already exists"
-	errUserAssociatedWithUserContainerBookmark   = "user associated with container bookmark"
-	errUserAssociatedWithContainerReportAsIssuer = "user associated with container report as issuer"
+	errUserNotFound      = "user not found"
+	errUserAlreadyExists = "username already exists"
 )
 
 // CreateUser handles the http request to create a user.
@@ -177,10 +175,6 @@ func (h *handler) DeleteUserByID(w http.ResponseWriter, r *http.Request, userID 
 		switch {
 		case errors.Is(err, domain.ErrUserNotFound):
 			notFound(w, errUserNotFound)
-		case errors.Is(err, domain.ErrUserAssociatedWithUserContainerBookmark):
-			conflict(w, errUserAssociatedWithUserContainerBookmark)
-		case errors.Is(err, domain.ErrUserAssociatedWithContainerReportAsIssuer):
-			conflict(w, errUserAssociatedWithContainerReportAsIssuer)
 		default:
 			internalServerError(w)
 		}

--- a/server/internal/transport/http/warehouse.go
+++ b/server/internal/transport/http/warehouse.go
@@ -15,7 +15,6 @@ import (
 const (
 	errWarehouseNotFound                            = "warehouse not found"
 	errWarehouseAlreadyHasMoreTrucksThanNewCapacity = "warehouse already has more trucks than the new capacity"
-	errWarehouseAssociatedWithWarehouseTruck        = "warehouse associated with truck"
 	errWarehouseAssociatedWithRouteDeparture        = "warehouse associated with route as departure"
 	errWarehouseAssociatedWithRouteArrival          = "warehouse associated with route as arrival"
 )
@@ -226,8 +225,6 @@ func (h *handler) DeleteWarehouseByID(w http.ResponseWriter, r *http.Request, wa
 		switch {
 		case errors.Is(err, domain.ErrWarehouseNotFound):
 			notFound(w, errWarehouseNotFound)
-		case errors.Is(err, domain.ErrWarehouseAssociatedWithWarehouseTruck):
-			conflict(w, errWarehouseAssociatedWithWarehouseTruck)
 		case errors.Is(err, domain.ErrWarehouseAssociatedWithRouteDeparture):
 			conflict(w, errWarehouseAssociatedWithRouteDeparture)
 		case errors.Is(err, domain.ErrWarehouseAssociatedWithRouteArrival):

--- a/web/src/locales/en.json
+++ b/web/src/locales/en.json
@@ -36,7 +36,7 @@
 	"containers.update.success": "Container updated successfully",
 	"containers.delete.success": "Container deleted successfully",
 	"containers.delete.conflict.title": "Conflict",
-	"containers.delete.conflict.description": "This container cannot be deleted because it's associated with a report, bookmark, or route.",
+	"containers.delete.conflict.description": "This container cannot be deleted because it's associated with a bookmark or route.",
 	"truck": "Truck",
 	"trucks": "Trucks",
 	"trucks.create.title": "Add truck",
@@ -68,7 +68,7 @@
 	"warehouses.notFound.description": "The warehouse you are looking for does not exist.",
 	"warehouses.delete.success": "Warehouse deleted successfully",
 	"warehouses.delete.conflict.title": "Conflict",
-	"warehouses.delete.conflict.description": "This warehouse cannot be deleted because it's associated with a truck or a route.",
+	"warehouses.delete.conflict.description": "This warehouse cannot be deleted because it's associated with a route.",
 	"landfill": "Landfill",
 	"landfills": "Landfills",
 	"landfills.create.title": "Add landfill",
@@ -124,5 +124,5 @@
 	"employees.notFound.description": "The employee you are looking for does not exist.",
 	"employees.delete.success": "Employee deleted successfully",
 	"employees.delete.conflict.title": "Conflict",
-	"employees.delete.conflict.description": "This employee cannot be deleted because it's associated with a report or a route."
+	"employees.delete.conflict.description": "This employee cannot be deleted because it's associated with a route."
 }

--- a/web/src/locales/pt.json
+++ b/web/src/locales/pt.json
@@ -36,7 +36,7 @@
 	"containers.update.success": "Contentor atualizado com sucesso",
 	"containers.delete.success": "Contentor eliminado com sucesso",
 	"containers.delete.conflict.title": "Conflito",
-	"containers.delete.conflict.description": "Este contentor não pode ser eliminado porque está associado a um reporte, marcador ou rota.",
+	"containers.delete.conflict.description": "Este contentor não pode ser eliminado porque está associado a um marcador ou rota.",
 	"truck": "Camião",
 	"trucks": "Camiões",
 	"trucks.create.title": "Adicionar camião",
@@ -68,7 +68,7 @@
 	"warehouses.notFound.description": "O armazém que procura não existe.",
 	"warehouses.delete.success": "Armazém eliminado com sucesso",
 	"warehouses.delete.conflict.title": "Conflito",
-	"warehouses.delete.conflict.description": "Este armazém não pode ser eliminado porque está associado a um camião ou a uma rota.",
+	"warehouses.delete.conflict.description": "Este armazém não pode ser eliminado porque está associado a uma rota.",
 	"landfill": "Aterro",
 	"landfills": "Aterros",
 	"landfills.create.title": "Adicionar aterro",
@@ -124,5 +124,5 @@
 	"employees.notFound.description": "O colaborador que procura não existe.",
 	"employees.delete.success": "Colaborador eliminado com sucesso",
 	"employees.delete.conflict.title": "Conflito",
-	"employees.delete.conflict.description": "Este colaborador não pode ser eliminado porque está associado a um reporte ou a uma rota."
+	"employees.delete.conflict.description": "Este colaborador não pode ser eliminado porque está associado a uma rota."
 }


### PR DESCRIPTION
## Summary

Update the database to automatically delete associations when the main resource is deleted.

## Changes

- Update migration by adding `CASCADE DELETE` on associations
- Update the service to respect the new DB changes
- Remove outdated 409 descriptions from the Swagger spec
