### PR TITLE
feat: update route endpoints to consider warehouse truck association

### DIFF
--- a/server/internal/domain/warehouse_truck.go
+++ b/server/internal/domain/warehouse_truck.go
@@ -4,10 +4,12 @@ import "errors"
 
 // Warehouse truck errors.
 var (
-	ErrWarehouseTruckAlreadyExists                = errors.New("warehouse truck already exists")                     // Returned when a warehouse truck association already exists.
-	ErrWarehouseTruckNotFound                     = errors.New("warehouse truck not found")                          // Returned when a warehouse truck association is not found.
-	ErrWarehouseTruckAssociatedWithRouteDeparture = errors.New("warehouse truck associated with route as departure") // Returned when a warehouse truck is associated with a route as a departure.
-	ErrWarehouseTruckAssociatedWithRouteArrival   = errors.New("warehouse truck associated with route as arrival")   // Returned when a warehouse truck is associated with a route as an arrival.
+	ErrWarehouseTruckAlreadyExists                   = errors.New("warehouse truck already exists")                         // Returned when a warehouse truck association already exists.
+	ErrWarehouseTruckNotFound                        = errors.New("warehouse truck not found")                              // Returned when a warehouse truck association is not found.
+	ErrWarehouseTruckAssociatedWithRouteDeparture    = errors.New("warehouse truck associated with route as departure")     // Returned when a warehouse truck is associated with a route as a departure.
+	ErrWarehouseTruckAssociatedWithRouteArrival      = errors.New("warehouse truck associated with route as arrival")       // Returned when a warehouse truck is associated with a route as an arrival.
+	ErrWarehouseTruckNotAssociatedWithRouteDeparture = errors.New("warehouse truck not associated with route as departure") // Returned when a warehouse truck is not associated with a route as a departure.
+	ErrWarehouseTruckNotAssociatedWithRouteArrival   = errors.New("warehouse truck not associated with route as arrival")   // Returned when a warehouse truck is not associated with a route as an arrival.
 )
 
 // WarehouseTruckPaginatedSort defines the field of the warehouse truck to sort.

--- a/server/internal/service/service.go
+++ b/server/internal/service/service.go
@@ -74,6 +74,7 @@ type Store interface {
 
 	CreateWarehouseTruck(ctx context.Context, tx pgx.Tx, warehouseID, truckID uuid.UUID) error
 	ListWarehouseTrucks(ctx context.Context, tx pgx.Tx, warehouseID uuid.UUID, filter domain.WarehouseTrucksPaginatedFilter) (domain.PaginatedResponse[domain.Truck], error)
+	ExistsWarehouseTruck(ctx context.Context, tx pgx.Tx, warehouseID, truckID uuid.UUID) (bool, error)
 	DeleteWarehouseTruck(ctx context.Context, tx pgx.Tx, warehouseID, truckID uuid.UUID) error
 
 	CreateLandfill(ctx context.Context, tx pgx.Tx, editableLandfill domain.EditableLandfill, roadID, municipalityID *int) (uuid.UUID, error)

--- a/server/internal/transport/http/route.go
+++ b/server/internal/transport/http/route.go
@@ -51,6 +51,10 @@ func (h *handler) CreateRoute(w http.ResponseWriter, r *http.Request) {
 			conflict(w, errRouteDepartureWarehouseNotFound)
 		case errors.Is(err, domain.ErrRouteArrivalWarehouseNotFound):
 			conflict(w, errRouteArrivalWarehouseNotFound)
+		case errors.Is(err, domain.ErrWarehouseTruckNotAssociatedWithRouteDeparture):
+			conflict(w, errWarehouseTruckNotAssociatedWithRouteDeparture)
+		case errors.Is(err, domain.ErrWarehouseTruckNotAssociatedWithRouteArrival):
+			conflict(w, errWarehouseTruckNotAssociatedWithRouteArrival)
 		default:
 			internalServerError(w)
 		}
@@ -177,6 +181,10 @@ func (h *handler) PatchRouteByID(w http.ResponseWriter, r *http.Request, routeID
 			conflict(w, errRouteDepartureWarehouseNotFound)
 		case errors.Is(err, domain.ErrRouteArrivalWarehouseNotFound):
 			conflict(w, errRouteArrivalWarehouseNotFound)
+		case errors.Is(err, domain.ErrWarehouseTruckNotAssociatedWithRouteDeparture):
+			conflict(w, errWarehouseTruckNotAssociatedWithRouteDeparture)
+		case errors.Is(err, domain.ErrWarehouseTruckNotAssociatedWithRouteArrival):
+			conflict(w, errWarehouseTruckNotAssociatedWithRouteArrival)
 		case errors.Is(err, domain.ErrRouteTruckPersonCapacityMinLimit):
 			conflict(w, errRouteTruckPersonCapacityMinLimit)
 		default:

--- a/server/internal/transport/http/warehouse_truck.go
+++ b/server/internal/transport/http/warehouse_truck.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	errWarehouseTruckAlreadyExists                = "warehouse truck association already exists"
-	errWarehouseTruckAssociatedWithRouteDeparture = "warehouse truck associated with route as departure"
-	errWarehouseTruckAssociatedWithRouteArrival   = "warehouse truck associated with route as arrival"
-	errWarehouseTruckNotFound                     = "warehouse truck association does not exist"
+	errWarehouseTruckAlreadyExists                   = "warehouse truck association already exists"
+	errWarehouseTruckAssociatedWithRouteDeparture    = "warehouse truck associated with route as departure"
+	errWarehouseTruckAssociatedWithRouteArrival      = "warehouse truck associated with route as arrival"
+	errWarehouseTruckNotAssociatedWithRouteDeparture = "warehouse truck not associated with route as departure"
+	errWarehouseTruckNotAssociatedWithRouteArrival   = "warehouse truck not associated with route as arrival"
+	errWarehouseTruckNotFound                        = "warehouse truck association does not exist"
 )
 
 // ListWarehouseTrucks handles the http request to list warehouse trucks.


### PR DESCRIPTION
Refs: closes #259

## Summary

Updated the Create and Update Route endpoints to reflect the warehouse truck association.
Now when creating/updating a route, the relevant warehouses and truck must be associated.
